### PR TITLE
drivers: ng_at86rf2xx: misc at86212b fixes

### DIFF
--- a/drivers/include/ng_at86rf2xx.h
+++ b/drivers/include/ng_at86rf2xx.h
@@ -51,21 +51,31 @@ extern "C" {
 #define NG_AT86RF2XX_TX_POWER_MAX       4
 
 /**
-  * @brief at86rf231's lowest supported channel
+  * @brief at86rf2xx channel config
+  * @{
   */
-#define NG_AT86RF2XX_MIN_CHANNEL        (11)
+#ifndef MODULE_AT86RF212B
+#define NG_AT86RF2XX_MIN_CHANNEL        (11U)
+#define NG_AT86RF2XX_MAX_CHANNEL        (26U)
+#define NG_AT86RF2XX_DEFAULT_CHANNEL    (17U)
+#else
+/* 212b has a sub-1GHz radio */
+#define NG_AT86RF2XX_MIN_CHANNEL        (0)
+#define NG_AT86RF2XX_MAX_CHANNEL        (10)
+#define NG_AT86RF2XX_DEFAULT_CHANNEL    (5)
+#endif
+/** @} */
 
 /**
   * @brief at86rf231's highest supported channel
   */
-#define NG_AT86RF2XX_MAX_CHANNEL        (26)
 
 #define NG_AT86RF2XX_MAX_PKT_LENGTH     (127)
 
 #define NG_AT86RF2XX_DEFAULT_ADDR_SHORT (0x0230)
 #define NG_AT86RF2XX_DEFAULT_ADDR_LONG  (0x1122334455667788)
-#define NG_AT86RF2XX_DEFAULT_CHANNEL    (17U)
-#define NG_AT86RF2XX_DEFAULT_PANID      (0x0023)
+
+#define NG_AT86RF2XX_DEFAULT_PANID      (0xffff)
 #define NG_AT86RF2XX_DEFAULT_TXPOWER    (0U)
 
 typedef enum {

--- a/drivers/ng_at86rf2xx/include/ng_at86rf2xx_registers.h
+++ b/drivers/ng_at86rf2xx/include/ng_at86rf2xx_registers.h
@@ -69,6 +69,8 @@ enum ng_at86rf2xx_register {
     NG_AT86RF2XX_REG__BATMON = 0x11,
     NG_AT86RF2XX_REG__XOSC_CTRL = 0x12,
 
+    NG_AT86RF2XX_REG__CC_CTRL_1 = 0x14,
+
     NG_AT86RF2XX_REG__RX_SYN = 0x15,
 
     NG_AT86RF2XX_REG__XAH_CTRL_1 = 0x17,
@@ -135,7 +137,9 @@ enum ng_at86rf2xx_trx_ctrl_1 {
 
 enum ng_at86rf2xx_trx_ctrl_2 {
     NG_AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE = 0x80,
+    NG_AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE = 0x4,
     NG_AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_DATA_RATE = 0x03,
+    NG_AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_SCRAM_EN = 0x20,
 };
 
 enum ng_at86rf2xx_irq_status {

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx.c
@@ -130,14 +130,21 @@ void ng_at86rf2xx_reset(ng_at86rf2xx_t *dev)
     dev->proto = NG_NETTYPE_UNDEF;
 #endif
     /* enable safe mode (protect RX FIFO until reading data starts) */
-    ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__TRX_CTRL_2,
-                           NG_AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
+    int tmp = NG_AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE;
+#ifdef MODULE_NG_AT86RF212
+    /* settings used by Linux 4.0rc at86rf212b driver */
+        tmp |= (NG_AT86RF2XX_TRX_CTRL_2_MASK__SUB_MODE
+                | NG_AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_SCRAM_EN);
+#endif
+    ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__TRX_CTRL_2, tmp);
     /* enable interrupts */
     ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__IRQ_MASK,
                            (NG_AT86RF2XX_IRQ_STATUS_MASK__RX_START |
                             NG_AT86RF2XX_IRQ_STATUS_MASK__TRX_END));
     /* go into RX state */
     ng_at86rf2xx_set_state(dev, STATE_RX_AACK_ON);
+
+    DEBUG("ng_at86rf2xx_reset(): reset complete.\n");
 }
 
 bool ng_at86rf2xx_cca(ng_at86rf2xx_t *dev)

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -5,6 +5,15 @@ FEATURES_REQUIRED = periph_spi periph_gpio
 
 BOARD_INSUFFICIENT_RAM := stm32f0discovery
 
+ifneq (,$(filter saml21-xpro,$(BOARD)))
+  DRIVER ?= ng_at86rf212b
+  export ATRF_SPI ?= SPI_0
+  export ATRF_CS ?= EXT1_SPI_SS
+  export ATRF_INT ?= EXT1_P09
+  export ATRF_RESET ?= EXT1_P07
+  export ATRF_SLEEP ?= EXT1_P10
+  export ATRF_SPI_SPEED ?= SPI_SPEED_1MHZ
+endif
 ifneq (,$(filter iot-lab_M3,$(BOARD)))
   DRIVER ?= ng_at86rf231
   export ATRF_SPI ?= SPI_0


### PR DESCRIPTION
These fixes allow link layer txtsnd to a Raspberry Pi using the same
transceiver under Linux.