### PR TITLE
opt_cortexm: Prefix and target triples

### DIFF
--- a/boards/Makefile.include.cortexm_common
+++ b/boards/Makefile.include.cortexm_common
@@ -1,5 +1,10 @@
+# Target triple for the build. Use arm-none-eabi if you are unsure.
+export TARGET_TRIPLE ?= arm-none-eabi
+
+# Toolchain prefix, defaults to target triple followed by a dash, you will most likely not need to touch this.
+export PREFIX ?= $(if $(TARGET_TRIPLE),$(TARGET_TRIPLE)-)
+
 # we build all cortex boards with the GNU toolchain
-export PREFIX = arm-none-eabi-
 include $(RIOTBOARD)/Makefile.include.gnu
 
 # define build specific options

--- a/boards/Makefile.include.gnu
+++ b/boards/Makefile.include.gnu
@@ -1,3 +1,4 @@
+export GDBPREFIX ?= $(PREFIX)
 export CC = $(PREFIX)gcc
 export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
@@ -5,4 +6,4 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export DBG = $(PREFIX)gdb
+export DBG = $(GDBPREFIX)gdb


### PR DESCRIPTION
I wanted to make the toolchain prefix a little more fine grained in order to prepare the make system for building with other compilers (e.g. Clang).