### PR TITLE
haukepetersen@opt cortex startup

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -41,6 +41,13 @@ extern uint32_t _sstack;
 extern uint32_t _estack;
 /** @} */
 
+/** @brief Interrupt stack canary value
+ *
+ * @note 0xe7fe is the ARM Thumb machine code equivalent of asm("bl #-2\n") or
+ * 'while (1);', i.e. an infinite loop.
+ */
+#define STACK_CANARY_WORD 0xE7FEE7FEu
+
 /**
  * @brief   Required by g++ cross compiler
  */
@@ -66,6 +73,11 @@ void reset_handler_default(void)
     uint32_t *src = &_etext;
     
     pre_startup();
+
+    /* fill stack space with canary values */
+    for (dst = &_sstack; dst < &_estack; ) {
+        *(dst++) = STACK_CANARY_WORD;
+    }
 
     /* load data section from flash to ram */
     for (dst = &_srelocate; dst < &_erelocate; ) {

--- a/cpu/k60/vector.c
+++ b/cpu/k60/vector.c
@@ -31,46 +31,20 @@
 #include "vectors_cortexm.h"
 #include "wdog.h"
 
-extern void *_estack[];
-extern void *_sstack[];
+/**
+ * memory markers as defined in the linker script
+ */
+extern uint32_t _estack;
+
+void pre_startup (void)
+{
+    /* disable the WDOG */
+    wdog_disable();
+}
 
 void dummy_handler(void)
 {
     dummy_handler_default();
-}
-
-/** @brief Interrupt stack canary value
- *
- * @note 0xe7fe is the ARM Thumb machine code equivalent of asm("bl #-2\n") or
- * 'while (1);', i.e. an infinite loop.
- */
-#define STACK_CANARY_WORD 0xE7FEE7FEu
-
-void pre_startup (void)
-{
-    /*
-     * Important: Keep this function as simple as possible, we must not use any
-     * stack space or we will crash, since we will overwrite all of the stack.
-     */
-    /* Disable watchdog first, it is necessary to do within 256 cycles.
-     * After this we will completely overwrite the stack so all necessary
-     * variables must be stored in registers or as immediate values in the
-     * machine code. */
-    wdog_disable();
-    /*
-     * The register keyword suggests to the compiler to place the variable in a
-     * register instead of on the stack. Using the register keyword is not a
-     * guarantee that the variable will be placed in a register. However, this
-     * function has been verified manually by disassembling the GCC output to
-     * ensure no stack is being used until after the write loop is finished.
-     */
-    register uint32_t *p;
-
-    /* Fill stack space with canary values */
-    for (p = (uint32_t *)_sstack; p < (uint32_t *)_estack; ++p) {
-        *p = STACK_CANARY_WORD;
-    }
-
 }
 
 /* Cortex-M specific interrupt vectors */


### PR DESCRIPTION
I fixed mulle pre_startup and moved the fill-stack-with-canary-values routine to Cortex M common. 
Tested on kw2x, fill-stack-with-canary-values routine works fine.