### PR TITLE
tests: periph_gpio: fix flank selection

### DIFF
--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -105,6 +105,18 @@ static int init_exti(int argc, char **argv)
     port = atoi(argv[1]);
     pin = atoi(argv[2]);
     flank = atoi(argv[3]);
+    switch (flank) {
+        case 0:
+            flank = GPIO_FALLING;
+            break;
+        case 1:
+            flank = GPIO_RISING;
+            break;
+        case 2:
+            flank = GPIO_BOTH;
+            break;
+    }
+
     if (argc >= 5) {
         pull = atoi(argv[3]);
     }

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -115,6 +115,9 @@ static int init_exti(int argc, char **argv)
         case 2:
             flank = GPIO_BOTH;
             break;
+        default:
+            printf("wrong flank setting.\n");
+            return 0;
     }
 
     if (argc >= 5) {
@@ -123,7 +126,7 @@ static int init_exti(int argc, char **argv)
     else {
         pull = 0;
     }
-    if (gpio_init_exti(GPIO(port, pin), flank, pull, cb, (void *)pin) < 0) {
+    if (gpio_init_exti(GPIO(port, pin), pull, flank, cb, (void *)pin) < 0) {
         printf("Error while initializing  PORT_%i.%02i as output\n", port, pin);
     }
     printf("PORT_%i.%02i initialized successful as output\n", port, pin);


### PR DESCRIPTION
0, 1, 2 don't cut it anymore.