### PR TITLE
msb-430: add missing SPI periph_conf definitions

### DIFF
--- a/boards/msb-430/include/periph_conf.h
+++ b/boards/msb-430/include/periph_conf.h
@@ -66,6 +66,26 @@ extern "C" {
 #define UART_TX_ISR         (USART1TX_VECTOR)
 /** @} */
 
+/**
+ * @brief   SPI configuration
+ * @{
+ */
+#define SPI_NUMOF           (1U)
+#define SPI_0_EN            (1U)
+
+/* SPI configuration */
+#define SPI_DEV             (USART_0)
+#define SPI_IE              (SFR->IE1)
+#define SPI_IF              (SFR->IFG1)
+#define SPI_IE_RX_BIT       (1 << 6)
+#define SPI_IE_TX_BIT       (1 << 7)
+#define SPI_ME              (SFR->ME1)
+#define SPI_ME_BIT          (1 << 6)
+#define SPI_PIN_MISO        GPIO(P5,2)
+#define SPI_PIN_MOSI        GPIO(P5,1)
+#define SPI_PIN_CLK         GPIO(P5,3)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
another one