### PR TITLE
boards/sodaq-autonomo: adapt changes for reworked SPI driver

### DIFF
--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -83,15 +83,12 @@ static const timer_conf_t timer_config[] = {
  * @name SPI configuration
  * @{
  */
-#define SPI_NUMOF           (1U)
-#define SPI_0_EN            1
-#define SPI_IRQ_PRIO        1
+static const spi_conf_t spi_config[] = {
+    /* dev, sck, mosi, miso */
+    { NRF_SPI0, 15, 13, 14 }
+};
 
-/* SPI_0 device configuration */
-#define SPI_0_DEV           NRF_SPI0
-#define SPI_0_PIN_MOSI      13
-#define SPI_0_PIN_MISO      14
-#define SPI_0_PIN_SCK       15
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 /**

--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -84,8 +84,11 @@ static const timer_conf_t timer_config[] = {
  * @{
  */
 static const spi_conf_t spi_config[] = {
-    /* dev, sck, mosi, miso */
-    { NRF_SPI0, 15, 13, 14 }
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 15,
+        .mosi = 13,
+        .miso = 14 }
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))

--- a/boards/arduino-due/include/periph_conf.h
+++ b/boards/arduino-due/include/periph_conf.h
@@ -88,6 +88,13 @@ static const uart_conf_t uart_config[] = {
 * @name SPI configuration
 * @{
 */
+static const spi_conf_t spi_config[] {
+    /* dev, clk, mosi, miso */
+    { SPI0, ID_SPI0, GPIO_PIN(PA, 25), GPIO_PIN(PA, 26), GPIO_PIN(PA, 27), GPIO_MUX_A }
+}
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+
 #define SPI_NUMOF           (1U)
 #define SPI_0_EN            1
 

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -43,8 +43,8 @@ extern "C" {
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}
  */
-#define AT86RF2XX_PARAMS_BOARD      {.spi = SPI_0, \
-                                     .spi_speed = SPI_SPEED_5MHZ, \
+#define AT86RF2XX_PARAMS_BOARD      {.spi = SPI_DEV(0), \
+                                     .spi_clk = SPI_CLK_5MHZ, \
                                      .cs_pin = GPIO_PIN(PB, 31), \
                                      .int_pin = GPIO_PIN(PB, 0), \
                                      .sleep_pin = GPIO_PIN(PA, 20), \

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -106,20 +106,20 @@ extern "C" {
 static const uart_conf_t uart_config[] = {
     /* device, RX pin, TX pin, mux, RX pad, TX pad */
     {
-        &SERCOM0->USART,
-        GPIO_PIN(PA,5),
-        GPIO_PIN(PA,4),
-        GPIO_MUX_D,
-        UART_PAD_RX_1,
-        UART_PAD_TX_0
+        .dev    = &SERCOM0->USART,
+        .rx_pin = GPIO_PIN(PA,5),
+        .tx_pin = GPIO_PIN(PA,4),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0
     },
     {
-        &SERCOM5->USART,
-        GPIO_PIN(PA,23),
-        GPIO_PIN(PA,22),
-        GPIO_MUX_D,
-        UART_PAD_RX_1,
-        UART_PAD_TX_0
+        .dev    = &SERCOM5->USART,
+        .rx_pin = GPIO_PIN(PA,23),
+        .tx_pin = GPIO_PIN(PA,22),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0
     }
 };
 

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -104,9 +104,23 @@ extern "C" {
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RX pin, TX pin, mux */
-    {&SERCOM0->USART, GPIO_PIN(PA,5),  GPIO_PIN(PA,4),  GPIO_MUX_D, SERCOM_RX_PAD_1, UART_TX_PAD_0},
-    {&SERCOM5->USART, GPIO_PIN(PA,23), GPIO_PIN(PA,22), GPIO_MUX_D, SERCOM_RX_PAD_1, UART_TX_PAD_0},
+    /* device, RX pin, TX pin, mux, RX pad, TX pad */
+    {
+        &SERCOM0->USART,
+        GPIO_PIN(PA,5),
+        GPIO_PIN(PA,4),
+        GPIO_MUX_D,
+        UART_PAD_RX_1,
+        UART_PAD_TX_0
+    },
+    {
+        &SERCOM5->USART,
+        GPIO_PIN(PA,23),
+        GPIO_PIN(PA,22),
+        GPIO_MUX_D,
+        UART_PAD_RX_1,
+        UART_PAD_TX_0
+    }
 };
 
 /* interrupt function name mapping */
@@ -168,10 +182,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_0_SCLK_MUX      GPIO_MUX_F
 #define SPI_0_MISO          GPIO_PIN(PC, 19)
 #define SPI_0_MISO_MUX      GPIO_MUX_F
-#define SPI_0_MISO_PAD      SERCOM_RX_PAD_0
+#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
 #define SPI_0_MOSI          GPIO_PIN(PB, 30)
 #define SPI_0_MOSI_MUX      GPIO_MUX_F
-#define SPI_0_MOSI_PAD      SPI_PAD_2_SCK_3
+#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 
 /*      SPI1             */
 #define SPI_1_DEV           SERCOM5->SPI
@@ -182,10 +196,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_1_SCLK_MUX      GPIO_MUX_D
 #define SPI_1_MISO          GPIO_PIN(PB, 02)
 #define SPI_1_MISO_MUX      GPIO_MUX_D
-#define SPI_1_MISO_PAD      SERCOM_RX_PAD_0
+#define SPI_1_MISO_PAD      SPI_PAD_MISO_0
 #define SPI_1_MOSI          GPIO_PIN(PB, 22)
 #define SPI_1_MOSI_MUX      GPIO_MUX_D
-#define SPI_1_MOSI_PAD      SPI_PAD_2_SCK_3
+#define SPI_1_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -169,37 +169,32 @@ static const pwm_conf_t pwm_config[] = {
  * @name SPI configuration
  * @{
  */
-#define SPI_NUMOF          (2)
-#define SPI_0_EN           1
-#define SPI_1_EN           1
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM4->SPI,
+        .miso_pin = GPIO_PIN(PC, 19),
+        .mosi_pin = GPIO_PIN(PB, 30),
+        .clk_pin  = GPIO_PIN(PC, 18),
+        .miso_mux = GPIO_MUX_F,
+        .mosi_mux = GPIO_MUX_F,
+        .clk_mux  = GPIO_MUX_F,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+    },
+    {
+        .dev      = &SERCOM5->SPI,
+        .miso_pin = GPIO_PIN(PB, 2),
+        .mosi_pin = GPIO_PIN(PB, 22),
+        .clk_pin  = GPIO_PIN(PB, 23),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+    }
+};
 
-/*      SPI0             */
-#define SPI_0_DEV           SERCOM4->SPI
-#define SPI_IRQ_0           SERCOM4_IRQn
-#define SPI_0_GCLK_ID       SERCOM4_GCLK_ID_CORE
-/* SPI 0 pin configuration */
-#define SPI_0_SCLK          GPIO_PIN(PC, 18)
-#define SPI_0_SCLK_MUX      GPIO_MUX_F
-#define SPI_0_MISO          GPIO_PIN(PC, 19)
-#define SPI_0_MISO_MUX      GPIO_MUX_F
-#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
-#define SPI_0_MOSI          GPIO_PIN(PB, 30)
-#define SPI_0_MOSI_MUX      GPIO_MUX_F
-#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
-
-/*      SPI1             */
-#define SPI_1_DEV           SERCOM5->SPI
-#define SPI_IRQ_1           SERCOM5_IRQn
-#define SPI_1_GCLK_ID       SERCOM5_GCLK_ID_CORE
-/* SPI 1 pin configuration */
-#define SPI_1_SCLK          GPIO_PIN(PB, 23)
-#define SPI_1_SCLK_MUX      GPIO_MUX_D
-#define SPI_1_MISO          GPIO_PIN(PB, 02)
-#define SPI_1_MISO_MUX      GPIO_MUX_D
-#define SPI_1_MISO_PAD      SPI_PAD_MISO_0
-#define SPI_1_MOSI          GPIO_PIN(PB, 22)
-#define SPI_1_MOSI_MUX      GPIO_MUX_D
-#define SPI_1_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 /**

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -102,38 +102,37 @@ extern "C" {
  * See Table 6.1 of the SAM D21 Datasheet
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RX pin, TX pin, mux, RX pad, TX pad */
     {
-        &SERCOM0->USART,
-        GPIO_PIN(PA,9),
-        GPIO_PIN(PA,10),
-        GPIO_MUX_C,
-        UART_PAD_RX_1,
-        UART_PAD_TX_2
+        .dev    = &SERCOM0->USART,
+        .rx_pin = GPIO_PIN(PA,9),
+        .tx_pin = GPIO_PIN(PA,10),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_2
     },
     {
-        &SERCOM5->USART,
-        GPIO_PIN(PB,31),
-        GPIO_PIN(PB,30),
-        GPIO_MUX_D,
-        UART_PAD_RX_1,
-        UART_PAD_TX_0_RTS_2_CTS_3
+        .dev    = &SERCOM5->USART,
+        .rx_pin = GPIO_PIN(PB,31),
+        .tx_pin = GPIO_PIN(PB,30),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0_RTS_2_CTS_3
     },
     {
-        &SERCOM4->USART,
-        GPIO_PIN(PB,13),
-        GPIO_PIN(PA,14),
-        GPIO_MUX_C,
-        UART_PAD_RX_1,
-        UART_PAD_TX_2
+        .dev    = &SERCOM4->USART,
+        .rx_pin = GPIO_PIN(PB,13),
+        .tx_pin = GPIO_PIN(PA,14),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_2
     },
     {
-        &SERCOM1->USART,
-        GPIO_PIN(PA,17),
-        GPIO_PIN(PA,18),
-        GPIO_MUX_C,
-        UART_PAD_RX_1,
-        UART_PAD_TX_2
+        .dev    = &SERCOM1->USART,
+        .rx_pin = GPIO_PIN(PA,17),
+        .tx_pin = GPIO_PIN(PA,18),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_2
     }
 };
 

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -184,27 +184,21 @@ static const pwm_conf_t pwm_config[] = {
  * @name SPI configuration
  * @{
  */
-#define SPI_NUMOF           (1)
-#define SPI_0_EN            1
-#define SPI_1_EN            0
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM3->SPI,
+        .miso_pin = GPIO_PIN(PA, 22),
+        .mosi_pin = GPIO_PIN(PA, 20),
+        .clk_pin  = GPIO_PIN(PA, 21),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+    },
+};
 
-/*      SPI0             */
-#define SPI_0_DEV           SERCOM3->SPI
-#define SPI_IRQ_0           SERCOM3_IRQn
-#define SPI_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-/* SPI 0 pin configuration */
-#define SPI_0_SCLK          GPIO_PIN(PA, 21)
-#define SPI_0_SCLK_MUX      GPIO_MUX_D
-#define SPI_0_MISO          GPIO_PIN(PA, 22)
-#define SPI_0_MISO_MUX      GPIO_MUX_C
-#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
-#define SPI_0_MOSI          GPIO_PIN(PA, 20)
-#define SPI_0_MOSI_MUX      GPIO_MUX_D
-#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
-
-// How/where do we define SS?
-#define SPI_0_SS            GPIO_PIN(PA, 23)
-
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 /**

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -103,10 +103,38 @@ extern "C" {
  */
 static const uart_conf_t uart_config[] = {
     /* device, RX pin, TX pin, mux, RX pad, TX pad */
-    {&SERCOM0->USART, GPIO_PIN(PA,9),  GPIO_PIN(PA,10), GPIO_MUX_C, SERCOM_RX_PAD_1, UART_TX_PAD_2},
-    {&SERCOM5->USART, GPIO_PIN(PB,31), GPIO_PIN(PB,30), GPIO_MUX_D, SERCOM_RX_PAD_1, UART_TX_RTS_CTS_PAD_0_2_3},
-    {&SERCOM4->USART, GPIO_PIN(PB,13), GPIO_PIN(PA,14), GPIO_MUX_C, SERCOM_RX_PAD_1, UART_TX_PAD_2},
-    {&SERCOM1->USART, GPIO_PIN(PA,17), GPIO_PIN(PA,18), GPIO_MUX_C, SERCOM_RX_PAD_1, UART_TX_PAD_2},
+    {
+        &SERCOM0->USART,
+        GPIO_PIN(PA,9),
+        GPIO_PIN(PA,10),
+        GPIO_MUX_C,
+        UART_PAD_RX_1,
+        UART_PAD_TX_2
+    },
+    {
+        &SERCOM5->USART,
+        GPIO_PIN(PB,31),
+        GPIO_PIN(PB,30),
+        GPIO_MUX_D,
+        UART_PAD_RX_1,
+        UART_PAD_TX_0_RTS_2_CTS_3
+    },
+    {
+        &SERCOM4->USART,
+        GPIO_PIN(PB,13),
+        GPIO_PIN(PA,14),
+        GPIO_MUX_C,
+        UART_PAD_RX_1,
+        UART_PAD_TX_2
+    },
+    {
+        &SERCOM1->USART,
+        GPIO_PIN(PA,17),
+        GPIO_PIN(PA,18),
+        GPIO_MUX_C,
+        UART_PAD_RX_1,
+        UART_PAD_TX_2
+    }
 };
 
 /* interrupt function name mapping */
@@ -170,10 +198,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_0_SCLK_MUX      GPIO_MUX_D
 #define SPI_0_MISO          GPIO_PIN(PA, 22)
 #define SPI_0_MISO_MUX      GPIO_MUX_C
-#define SPI_0_MISO_PAD      SERCOM_RX_PAD_0
+#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
 #define SPI_0_MOSI          GPIO_PIN(PA, 20)
 #define SPI_0_MOSI_MUX      GPIO_MUX_D
-#define SPI_0_MOSI_PAD      SPI_PAD_2_SCK_3
+#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 
 // How/where do we define SS?
 #define SPI_0_SS            GPIO_PIN(PA, 23)

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -192,52 +192,28 @@ static const uart_conf_t uart_config[] = {
  * @name SPI configuration
  * @{
  */
-#define SPI_NUMOF           (2U)
-#define SPI_0_EN            1
-#define SPI_1_EN            1
-#define SPI_IRQ_PRIO        1
+static const spi_conf_t spi_config[] = {
+    {
+        SPI1,
+        GPIO_PIN(PORT_A, 7),
+        GPIO_PIN(PORT_A, 6),
+        GPIO_PIN(PORT_A, 5),
+        5,
+        BUS_APB2,
+        RCC_APB2ENR_SPI1EN
+    },
+    {
+        SPI2,
+        GPIO_PIN(PORT_B, 15),
+        GPIO_PIN(PORT_B, 14),
+        GPIO_PIN(PORT_B, 13),
+        5,
+        BUS_APB1,
+        RCC_APB1ENR_SPI2EN
+    }
+};
 
-/* SPI 0 device config */
-#define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
-#define SPI_0_BUS_DIV           1   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
-#define SPI_0_IRQ               SPI1_IRQn
-#define SPI_0_IRQ_HANDLER       isr_spi1
-/* SPI 0 pin configuration */
-#define SPI_0_SCK_PORT          GPIOA
-#define SPI_0_SCK_PIN           5
-#define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define SPI_0_MISO_PORT         GPIOA
-#define SPI_0_MISO_PIN          6
-#define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define SPI_0_MOSI_PORT         GPIOA
-#define SPI_0_MOSI_PIN          7
-#define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-
-/* SPI 1 device config */
-#define SPI_1_DEV               SPI2
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
-#define SPI_1_BUS_DIV           0   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
-#define SPI_1_IRQ               SPI2_IRQn
-#define SPI_1_IRQ_HANDLER       isr_spi2
-/* SPI 1 pin configuration */
-#define SPI_1_SCK_PORT          GPIOB
-#define SPI_1_SCK_PIN           13
-#define SPI_1_SCK_AF            5
-#define SPI_1_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
-#define SPI_1_MISO_PORT         GPIOB
-#define SPI_1_MISO_PIN          14
-#define SPI_1_MISO_AF           5
-#define SPI_1_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
-#define SPI_1_MOSI_PORT         GPIOB
-#define SPI_1_MOSI_PIN          15
-#define SPI_1_MOSI_AF           5
-#define SPI_1_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
 /**

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -14,6 +14,7 @@
  * @brief       Platform-independent kernel initilization
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -27,6 +28,7 @@
 #include "lpm.h"
 #include "irq.h"
 #include "log.h"
+#include "periph/spi.h"
 
 #ifdef MODULE_SCHEDSTATISTICS
 #include "sched.h"
@@ -88,6 +90,14 @@ static char idle_stack[THREAD_STACKSIZE_IDLE];
 void kernel_init(void)
 {
     (void) irq_disable();
+
+    /* TODO: should this be located here? */
+#ifdef SPI_NUMOF
+    /* initialize configured SPI devices */
+    for (int i = 0; i < (int)SPI_NUMOF; i++) {
+        spi_init(SPI_DEV(i));
+    }
+#endif
 
     thread_create(idle_stack, sizeof(idle_stack),
             THREAD_PRIORITY_IDLE,

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -27,16 +27,6 @@
 /* guard this file in case no SPI device is defined */
 #if SPI_NUMOF
 
-/* static port mapping */
-static NRF_SPI_Type *const spi[] = {
-#if SPI_0_EN
-    SPI_0_DEV,
-#endif
-#if SPI_1_EN
-    SPI_1_DEV
-#endif
-};
-
 /**
  * @brief   array holding one pre-initialized mutex for each SPI device
  */
@@ -49,188 +39,100 @@ static mutex_t locks[] =  {
 #endif
 };
 
-int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
+static inline NRF_SPI_Type *dev(spi_t bus)
 {
-    spi_poweron(dev);
-
-    /* disable the device -> nRF51822 reference 3.0 26.1.1 and 27.1*/
-    spi[dev]->ENABLE = 0;
-
-    switch(dev) {
-#if SPI_0_EN
-        case SPI_0:
-            /* disable TWI Interface */
-            NRF_TWI0->ENABLE = 0;
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            /* disable SPI Slave */
-            NRF_SPIS1->ENABLE = 0;
-            /* disable TWI Interface */
-            NRF_TWI1->ENABLE = 0;
-            break;
-#endif
-        default:
-            return -1;
-    }
-
-    /* configure direction of used pins */
-    spi_conf_pins(dev);
-    /* configure SPI mode */
-    switch (conf) {
-        case SPI_CONF_FIRST_RISING:
-            spi[dev]->CONFIG = (SPI_CONFIG_CPOL_ActiveHigh << 2) | (SPI_CONFIG_CPHA_Leading << 1);
-            break;
-        case SPI_CONF_SECOND_RISING:
-            spi[dev]->CONFIG = (SPI_CONFIG_CPOL_ActiveHigh << 2) | (SPI_CONFIG_CPHA_Trailing << 1);
-            break;
-        case SPI_CONF_FIRST_FALLING:
-            spi[dev]->CONFIG = (SPI_CONFIG_CPOL_ActiveLow << 2) | (SPI_CONFIG_CPHA_Leading << 1);
-            break;
-        case SPI_CONF_SECOND_FALLING:
-            spi[dev]->CONFIG = (SPI_CONFIG_CPOL_ActiveLow << 2) | (SPI_CONFIG_CPHA_Trailing << 1);
-            break;
-    }
-
-    /* select bus speed */
-    switch (speed) {
-        case SPI_SPEED_100KHZ:          /* 125 KHz for this device */
-            spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_K125;
-            break;
-        case SPI_SPEED_400KHZ:          /* 500 KHz for this device */
-            spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_K500;
-            break;
-        case SPI_SPEED_1MHZ:            /* 1 MHz for this device */
-            spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_M1;
-            break;
-        case SPI_SPEED_5MHZ:            /* 4 MHz for this device */
-            spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_M4;
-            break;
-        case SPI_SPEED_10MHZ:           /* 8 MHz for this device */
-            spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_M8;
-            break;
-    }
-
-    /* finally enable the device */
-    spi[dev]->ENABLE = 1;
-    return 0;
+    return spi_config[bus].dev;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init(spi_t bus, spi_cs_t cs)
 {
-    (void) dev;
-    (void) conf;
-    (void) cb;
-    /* This API is incompatible with nRF51 SPIS */
-    return -1;
-}
-
-int spi_conf_pins(spi_t dev)
-{
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            /* set pin direction */
-            NRF_GPIO->DIRSET = (1 << SPI_0_PIN_MOSI) | (1 << SPI_0_PIN_SCK);
-            NRF_GPIO->DIRCLR = (1 << SPI_0_PIN_MISO);
-            /* select pins to be used by SPI */
-            spi[dev]->PSELMOSI = SPI_0_PIN_MOSI;
-            spi[dev]->PSELMISO = SPI_0_PIN_MISO;
-            spi[dev]->PSELSCK = SPI_0_PIN_SCK;
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            /* set pin direction */
-            NRF_GPIO->DIRSET = (1 << SPI_1_PIN_MOSI) | (1 << SPI_1_PIN_SCK);
-            NRF_GPIO->DIRCLR = (1 << SPI_1_PIN_MISO);
-            /* select pins to be used by SPI */
-            spi[dev]->PSELMOSI = SPI_1_PIN_MOSI;
-            spi[dev]->PSELMISO = SPI_1_PIN_MISO;
-            spi[dev]->PSELSCK = SPI_1_PIN_SCK;
-            break;
-#endif
-        default:
-            return -1;
-    }
-    return 0;
-}
-
-int spi_acquire(spi_t dev)
-{
-    if ((unsigned int)dev >= SPI_NUMOF) {
+    if ((bus >= SPI_NUMOF) || (cs == SPI_CS_UNDEF)) {
         return -1;
     }
-    mutex_lock(&locks[dev]);
+
+    mutex_lock(&locks[bus]);
+
+    /* set pin direction */
+    NRF_GPIO->DIRSET = ((1 << spi_config[bus].sck) |
+                        (1 << spi_config[bus].mosi));
+    NRF_GPIO->DIRCLR =  (1 << spi_config[bus].miso);
+    /* select pins for the SPI device */
+    dev(bus)->PSELSCK  = spi_config[bus].sck;
+    dev(bus)->PSELMOSI = spi_config[bus].mosi;
+    dev(bus)->PSELMISO = spi_config[bus].miso;
+
+    mutex_unlock(&locks[bus]);
+
     return 0;
 }
 
-int spi_release(spi_t dev)
+int spi_acquire(spi_t bus, spi_mode_t mode, spi_clk_t clk, spi_cs_t cs)
 {
-    if ((unsigned int)dev >= SPI_NUMOF) {
+    if ((bus >= SPI_NUMOF) || (cs == SPI_CS_UNDEF)) {
         return -1;
     }
+
+    mutex_lock(&locks[bus]);
+    /* power on the bus */
+    dev(bus)->POWER = 1;
+    /* configure bus */
+    dev(bus)->CONFIG = mode;
+    dev(bus)->FREQUENCY = clk;
+    /* enable the bus */
+    dev(bus)->ENABLE = 1;
+
+    return 0;
+}
+
+void spi_release(spi_t bus)
+{
+    /* power off everything */
+    dev(bus)->ENABLE = 0;
+    dev(bus)->POWER = 0;
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        uint8_t *out, uint8_t *in, size_t len)
 {
-    return spi_transfer_bytes(dev, &out, in, 1);
-}
-
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
-{
-    if ((unsigned int)dev >= SPI_NUMOF) {
-        return -1;
-    }
+    gpio_clear((gpio_t)cs);
 
     for (unsigned i = 0; i < length; i++) {
-        char tmp = (out) ? out[i] : 0;
+        uint8_t tmp = (out) ? out[i] : 0;
+
         spi[dev]->EVENTS_READY = 0;
         spi[dev]->TXD = (uint8_t)tmp;
-        while (spi[dev]->EVENTS_READY != 1) {}
-        tmp = (char)spi[dev]->RXD;
+        while (spi[dev]->EVENTS_READY != 1);
+        tmp = (uint8_t)spi[dev]->RXD;
+
         if (in) {
             in[i] = tmp;
         }
     }
 
-    return length;
-}
-
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
-{
-    spi_transfer_byte(dev, reg, 0);
-    return spi_transfer_byte(dev, out, in);
-}
-
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
-{
-    spi_transfer_byte(dev, reg, 0);
-    return spi_transfer_bytes(dev, out, in, length);
-}
-
-void spi_transmission_begin(spi_t dev, char reset_val)
-{
-    (void) dev;
-    (void) reset_val;
-    /* spi slave is not implemented */
-}
-
-void spi_poweron(spi_t dev)
-{
-    if ((unsigned int)dev < SPI_NUMOF) {
-        spi[dev]->POWER = 1;
+    if (!cont) {
+        gpio_set((gpio_t)cs);
     }
 }
 
-void spi_poweroff(spi_t dev)
+void spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont,
+                       uint8_t out, uint8_t *in)
 {
-    if ((unsigned int)dev < SPI_NUMOF) {
-        spi[dev]->POWER = 0;
-    }
+    spi_transfer_bytes(bus, cs, cont, &out, in, 1);
+}
+
+void spi_transfer_reg(spi_t bus, spi_cs_t cs,
+                      uint8_t reg, uint8_t out, uint8_t *in)
+{
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, &out, in, 1);
+}
+
+void spi_transfer_regs(spi_t bus, spi_cs_t cs,
+                       uint8_t reg, uint8_t *out, uint8_t *in, size_t len)
+{
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, out, in, len);
 }
 
 #endif /* SPI_NUMOF */

--- a/cpu/nrf5x_common/include/periph_cpu.h
+++ b/cpu/nrf5x_common/include/periph_cpu.h
@@ -122,6 +122,31 @@ typedef struct {
     uint8_t irqn;
 } timer_conf_t;
 
+
+#define HAVE_SPI_MODE_T
+typedef enum {
+    SPI_MODE_0 = 0,                                             /**< CPOL=0, CPHA=0 */
+    SPI_MODE_1 = SPI_CONFIG_CPHA_Msk,                           /**< CPOL=0, CPHA=1 */
+    SPI_MODE_2 = SPI_CONFIG_CPOL_Msk,                           /**< CPOL=1, CPHA=0 */
+    SPI_MODE_3 = (SPI_CONFIG_CPOL_Msk | SPI_CONFIG_CPHA_Msk)    /**< CPOL=1, CPHA=1 */
+} spi_mode_t;
+
+#define HAVE_SPI_CLK_T
+typedef enum {
+    SPI_CLK_100KHZ = SPI_FREQUENCY_FREQUENCY_K125,  /**< 100KHz */
+    SPI_CLK_400KHZ = SPI_FREQUENCY_FREQUENCY_K500,  /**< 400KHz */
+    SPI_CLK_1MHZ   = SPI_FREQUENCY_FREQUENCY_M1,    /**< 1MHz */
+    SPI_CLK_5MHZ   = SPI_FREQUENCY_FREQUENCY_M4,    /**< 5MHz */
+    SPI_CLK_10MHZ  = SPI_FREQUENCY_FREQUENCY_M8     /**< 10MHz */
+} spi_clk_t;
+
+typedef struct {
+    NRF_SPI_Type *dev;
+    uint8_t csk;
+    uint8_t mosi;
+    uint8_t miso;
+} spi_conf_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf5x_common/include/periph_cpu.h
+++ b/cpu/nrf5x_common/include/periph_cpu.h
@@ -63,6 +63,11 @@ extern "C" {
  */
 #define GPIO_MODE(oe, ic, pr)   (oe | (ic << 1) | (pr << 2))
 
+/**
+ * @brief   No support for HW chip select so far...
+ */
+#define SPI_HWCS(x)         (GPIO_UNDEF)
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
@@ -142,7 +147,7 @@ typedef enum {
 
 typedef struct {
     NRF_SPI_Type *dev;
-    uint8_t csk;
+    uint8_t sclk;
     uint8_t mosi;
     uint8_t miso;
 } spi_conf_t;

--- a/cpu/sam21_common/include/periph_cpu_common.h
+++ b/cpu/sam21_common/include/periph_cpu_common.h
@@ -34,7 +34,7 @@ extern "C" {
  * @brief   Use shared SPI functions
  * @{
  */
-#define PERIPH_SPI_NEEDS_TRANSFER_BYTES
+#define PERIPH_SPI_NEEDS_TRANSFER_BYTE
 #define PERIPH_SPI_NEEDS_TRANSFER_REG
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */

--- a/cpu/sam21_common/include/periph_cpu_common.h
+++ b/cpu/sam21_common/include/periph_cpu_common.h
@@ -87,33 +87,44 @@ typedef enum {
 } gpio_mux_t;
 
 /**
- * @brief   Possible pad selections for SERCOM RX (inspired by Arduino)
+ * @brief   Available values for SERCOM UART RX pad selection
  */
 typedef enum {
-    SERCOM_RX_PAD_0 = 0x0,  /**< select pad 0 */
-    SERCOM_RX_PAD_1 = 0x1,  /**< select pad 1 */
-    SERCOM_RX_PAD_2 = 0x2,  /**< select pad 2 */
-    SERCOM_RX_PAD_3 = 0x3,  /**< select pad 3 */
-} sercom_rxpad_t;
+    UART_PAD_RX_0 = 0x0,    /**< use pad 0 for RX line */
+    UART_PAD_RX_1 = 0x1,    /**< select pad 1 */
+    UART_PAD_RX_2 = 0x2,    /**< select pad 2 */
+    UART_PAD_RX_3 = 0x3,    /**< select pad 3 */
+} uart_rxpad_t;
 
 /**
- * @brief   Possible pad selections for SERCOM UART TX (inspired by Arduino)
+ * @brief   Available values for SERCOM UART TX pad selection
  */
 typedef enum {
-    UART_TX_PAD_0 = 0x0,    /**< select pad 0, only UART */
-    UART_TX_PAD_2 = 0x1,    /**< select pad 2, only UART */
-    UART_TX_RTS_CTS_PAD_0_2_3 = 0x2,    /**< select pad 0, 2 and 3, only UART, TX on PAD0, RTS on PAD2 and CTS on PAD3 */
-} sercom_uart_txpad_t;
+    UART_PAD_TX_0             = 0x0,    /**< select pad 0 */
+    UART_PAD_TX_2             = 0x1,    /**< select pad 2 */
+    UART_PAD_TX_0_RTS_2_CTS_3 = 0x2,    /**< TX is pad 0, on top RTS on pad 2
+                                         *   and CTS on pad 3 */
+} uart_txpad_t;
 
 /**
- * @brief   Possible pad selections for SERCOM SPI output (inspired by Arduino)
+ * @brief   Available values for SERCOM SPI MISO pad selection
  */
 typedef enum {
-    SPI_PAD_0_SCK_1 = 0,    /**< select pad 0, SCK pad1, only SPI */
-    SPI_PAD_2_SCK_3 = 1,    /**< select pad 2, SCK pad3, only SPI */
-    SPI_PAD_3_SCK_1 = 2,    /**< select pad 3, SCK pad1, only SPI */
-    SPI_PAD_0_SCK_3 = 3,    /**< select pad 0, SCK pad3, only SPI */
-} sercom_spi_txpad_t;
+    SPI_PAD_MISO_0 = 0x0,       /**< use pad 0 for MISO line */
+    SPI_PAD_MISO_1 = 0x1,       /**< use pad 0 for MISO line */
+    SPI_PAD_MISO_2 = 0x2,       /**< use pad 0 for MISO line */
+    SPI_PAD_MISO_3 = 0x3,       /**< use pad 0 for MISO line */
+} spi_misopad_t;
+
+/**
+ * @brief   Available values for SERCOM SPI MOSI and SCK pad selection
+ */
+typedef enum {
+    SPI_PAD_MOSI_0_SCK_1 = 0x0, /**< use pad 0 for MOSI, pad 1 for SCK */
+    SPI_PAD_MOSI_2_SCK_3 = 0x1, /**< use pad 2 for MOSI, pad 3 for SCK */
+    SPI_PAD_MOSI_3_SCK_1 = 0x2, /**< use pad 3 for MOSI, pad 1 for SCK */
+    SPI_PAD_MOSI_0_SCK_3 = 0x3, /**< use pad 0 for MOSI, pad 3 for SCK */
+} spi_mosipad_t;
 
 /**
  * @brief   Possible selections for SERCOM SPI data size (inspired by Arduino)

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -127,6 +127,23 @@ typedef enum {
     GPIO_MUX_B = 1,         /**< alternate function B */
 } gpio_mux_t;
 
+#ifndef HAVE_SPI_MODE_T
+typedef enum {
+    SPI_MODE_0 = (SPI_CSR_NCPHA),                   /**< CPOL=0, CPHA=0 */
+    SPI_MODE_1 = (0),                               /**< CPOL=0, CPHA=1 */
+    SPI_MODE_2 = (SPI_CSR_CPOL | SPI_CSR_NCPHA),    /**< CPOL=1, CPHA=0 */
+    SPI_MODE_3 = (SPI_CSR_CPOL)                     /**< CPOL=1, CPHA=1 */
+} spi_mode_t;
+
+#ifndef HAVE_SPI_CLK_T
+typedef enum {
+    SPI_CLK_100KHZ = (CLOCK_CORECLOCK / 100000),    /**< 100KHz */
+    SPI_CLK_400KHZ = (CLOCK_CORECLOCK / 400000),    /**< 400KHz */
+    SPI_CLK_1MHZ   = (CLOCK_CORECLOCK / 1000000),   /**< 1MHz */
+    SPI_CLK_5MHZ   = (CLOCK_CORECLOCK / 5000000),   /**< 5MHz */
+    SPI_CLK_10MHZ  = (CLOCK_CORECLOCK / 10000000)   /**< 10MHz */
+} spi_clk_t;
+
 /**
  * @brief   Timer configuration data
  */
@@ -148,6 +165,22 @@ typedef struct {
     uint8_t pmc_id;         /**< bit in the PMC register of the device*/
     uint8_t irqn;           /**< interrupt number of the device */
 } uart_conf_t;
+
+/**
+ * @brief   SPI configuration data
+ */
+typedef struct {
+    Spi *dev;
+    uint8_t id;
+    gpio_t clk;
+    gpio_t mosi;
+    gpio_t miso;
+    gpio_mux_t mux;
+} spi_conf_t;
+
+
+
+void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 
 #ifdef __cplusplus
 }

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -1,9 +1,10 @@
 /*
 * Copyright (C) 2014 Hamburg University of Applied Sciences
+*               2016 Freie Universität Berlin
 *
-* This file is subject to the terms and conditions of the GNU Lesser General
-* Public License v2.1. See the file LICENSE in the top level directory for more
-* details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
 */
 
 /**
@@ -23,18 +24,11 @@
 
 #include "cpu.h"
 #include "mutex.h"
-#include "sched.h"
-#include "thread.h"
-#include "periph/gpio.h"
-#include "periph_conf.h"
 #include "periph/spi.h"
-#include "sam3x8e.h"
-
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
+#include "periph/gpio.h"
 
 /**
- * @brief Array holding one pre-initialized mutex for each SPI device
+ * @brief   Array holding one pre-initialized mutex for each SPI device
  */
 static mutex_t locks[] =  {
 #if SPI_0_EN
@@ -48,326 +42,103 @@ static mutex_t locks[] =  {
 #endif
 };
 
-typedef struct {
-    char(*cb)(char data);
-} spi_state_t;
-
-static inline void irq_handler_transfer(Spi *spi, spi_t dev);
-
-static spi_state_t spi_config[SPI_NUMOF];
-
-void spi_poweron(spi_t dev)
+static inline Spi *dev(spi_t bus)
 {
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            SPI_0_CLKEN();
-            SPI_0_MISO_PORT_CLKEN();
-            SPI_0_MOSI_PORT_CLKEN();
-            SPI_0_SCK_PORT_CLKEN();
-            break;
-#endif /* SPI_0_EN */
-    }
+    return spi_config[bus].dev;
 }
 
-void spi_poweroff(spi_t dev)
+static inline clk_en(spi_t bus)
 {
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            while (!(SPI_0_DEV->SPI_SR & SPI_SR_SPIENS)) {} /* not busy anymore */
-            SPI_0_CLKDIS();
-            NVIC_DisableIRQ(SPI_0_IRQ);
-            break;
-#endif /* SPI_0_EN */
-    }
+    PMC->PMC_PCER0 |= (1 << spi_config[bus].id);
 }
 
-int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
+static inline clk_dis(spi_t bus)
 {
-    uint8_t speed_divider;
-    Spi *spi_port;
-
-    spi_poweron(dev);
-
-    switch (speed) {
-        case SPI_SPEED_400KHZ:
-            speed_divider = 210;
-            break;
-
-        case SPI_SPEED_1MHZ:
-            speed_divider = 84;
-            break;
-
-        case SPI_SPEED_5MHZ:
-            speed_divider = 17;
-            break;
-
-        case SPI_SPEED_10MHZ: /* this might be too fast */
-            speed_divider = 8;
-            break;
-
-        default:
-            return -1;
-    }
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            break;
-#endif /* SPI_0_EN */
-        default:
-            return -2;
-    }
-
-    /* Configure SCK, MISO and MOSI pin */
-    spi_conf_pins(dev);
-
-    /***************** SPI-Init *****************/
-
-    /* Chip Select Register */
-    spi_port->SPI_CSR[0] = 0; /* This is index 0 since we don't use internal CS-Signals */
-
-    switch (conf) {
-        case SPI_CONF_FIRST_RISING:
-            spi_port->SPI_CSR[0] &= ~SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] |= SPI_CSR_NCPHA;
-            break;
-
-        case SPI_CONF_SECOND_RISING:
-            spi_port->SPI_CSR[0] &= ~SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] &= ~SPI_CSR_NCPHA;
-            break;
-
-        case SPI_CONF_FIRST_FALLING:
-            spi_port->SPI_CSR[0] |= SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] |= SPI_CSR_NCPHA;
-            break;
-
-        case SPI_CONF_SECOND_FALLING:
-            spi_port->SPI_CSR[0] |= SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] &= ~ SPI_CSR_NCPHA;
-            break;
-
-        default:
-            return -2;
-    }
-
-    spi_port->SPI_CSR[0] |= SPI_CSR_SCBR(speed_divider);
-    spi_port->SPI_CSR[0] |= SPI_CSR_BITS_8_BIT;
-
-    /* Control Register */
-    spi_port->SPI_CR |= SPI_CR_SPIEN;
-    /* Mode Register */
-    spi_port->SPI_MR = 0;
-    spi_port->SPI_MR |= SPI_MR_MSTR;
-    spi_port->SPI_MR |= SPI_MR_MODFDIS;
-    spi_port->SPI_MR &= ~SPI_MR_PS;
-    spi_port->SPI_MR &= ~SPI_MR_PCS(0);
-
-    return 0;
+    PMC->PMC_PCER0 &= ~(1 << spi_config[bus].id);
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+
+int spi_init_pins(spi_t bus, spi_cs_t cs)
 {
-    Spi *spi_port;
-
-    spi_poweron(dev);
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            NVIC_SetPriority(SPI_0_IRQ, SPI_0_IRQ_PRIO);
-            NVIC_EnableIRQ(SPI_0_IRQ);
-            /* Initialize predefined NSS pin as output so it is "disabled" */
-            PIOA->PIO_PER |= PIO_PA28A_SPI0_NPCS0;
-            PIOA->PIO_OER |= PIO_PA28A_SPI0_NPCS0;
-            break;
-#endif /* SPI_0_EN */
-        default:
-            return -1;
-    }
-
-    /* Configure SCK, MISO and MOSI pin */
-    spi_conf_pins(dev);
-
-    /***************** SPI-Init *****************/
-
-    /* Chip Select Register */
-    spi_port->SPI_CSR[0] = 0;
-
-    switch (conf) {
-        case SPI_CONF_FIRST_RISING:
-            spi_port->SPI_CSR[0] &= ~SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] |= SPI_CSR_NCPHA;
-            break;
-
-        case SPI_CONF_SECOND_RISING:
-            spi_port->SPI_CSR[0] &= ~SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] &= ~SPI_CSR_NCPHA;
-            break;
-
-        case SPI_CONF_FIRST_FALLING:
-            spi_port->SPI_CSR[0] |= SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] |= SPI_CSR_NCPHA;
-            break;
-
-        case SPI_CONF_SECOND_FALLING:
-            spi_port->SPI_CSR[0] |= SPI_CSR_CPOL;
-            spi_port->SPI_CSR[0] &= ~ SPI_CSR_NCPHA;
-            break;
-
-        default:
-            return -1;
-    }
-
-    /* Control Register */
-    spi_port->SPI_CR |= SPI_CR_SPIEN;
-    /* Mode Register */
-    spi_port->SPI_MR = 0;
-    spi_port->SPI_MR |= SPI_MR_MODFDIS;
-    /* Enable SPI interrupts */
-    spi_port->SPI_IER = 0;
-    spi_port->SPI_IDR = ~(0);
-    spi_port->SPI_IER |= 1;
-    spi_port->SPI_IDR &= ~SPI_IDR_RDRF;
-
-    /* Set callback */
-    spi_config[dev].cb = cb;
-
-    return 0;
-}
-
-int spi_conf_pins(spi_t dev)
-{
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            /***************** PIO-Init *****************/
-            /* Push-pull configuration */
-            SPI_0_MISO_PORT->PIO_MDER &= ~SPI_0_MISO_PIN;
-            SPI_0_MISO_PORT->PIO_MDDR |= SPI_0_MISO_PIN;
-            SPI_0_MOSI_PORT->PIO_MDER &= ~SPI_0_MOSI_PIN;
-            SPI_0_MOSI_PORT->PIO_MDDR |= SPI_0_MOSI_PIN;
-            SPI_0_SCK_PORT->PIO_MDER &= ~SPI_0_SCK_PIN;
-            SPI_0_SCK_PORT->PIO_MDDR |= SPI_0_SCK_PIN;
-
-            /* With pull-up resistors */
-            SPI_0_MISO_PORT->PIO_PUDR &= ~SPI_0_MISO_PIN;
-            SPI_0_MISO_PORT->PIO_PUER |= SPI_0_MISO_PIN;
-            SPI_0_MOSI_PORT->PIO_PUDR &= ~SPI_0_MOSI_PIN;
-            SPI_0_MOSI_PORT->PIO_PUER |= SPI_0_MOSI_PIN;
-            SPI_0_SCK_PORT->PIO_PUDR &= ~SPI_0_SCK_PIN;
-            SPI_0_SCK_PORT->PIO_PUER |= SPI_0_SCK_PIN;
-
-            /* Clear output */
-            SPI_0_MISO_PORT->PIO_SODR &= ~SPI_0_MISO_PIN;
-            SPI_0_MISO_PORT->PIO_CODR |= SPI_0_MISO_PIN;
-            SPI_0_MOSI_PORT->PIO_SODR &= ~SPI_0_MOSI_PIN;
-            SPI_0_MOSI_PORT->PIO_CODR |= SPI_0_MOSI_PIN;
-            SPI_0_SCK_PORT->PIO_SODR &= ~SPI_0_SCK_PIN;
-            SPI_0_SCK_PORT->PIO_CODR |= SPI_0_SCK_PIN;
-
-            /* Peripheral Function Selection */
-            SPI_0_MISO_PORT->PIO_PER &= ~SPI_0_MISO_PIN;
-            SPI_0_MISO_PORT->PIO_PDR |= SPI_0_MISO_PIN;
-            SPI_0_MOSI_PORT->PIO_PER &= ~SPI_0_MOSI_PIN;
-            SPI_0_MOSI_PORT->PIO_PDR |= SPI_0_MOSI_PIN;
-            SPI_0_SCK_PORT->PIO_PER &= ~SPI_0_SCK_PIN;
-            SPI_0_SCK_PORT->PIO_PDR |= SPI_0_SCK_PIN;
-
-            /* Peripheral A */
-            SPI_0_MISO_PORT->PIO_ABSR &= ~SPI_0_MISO_PIN;
-            SPI_0_MOSI_PORT->PIO_ABSR &= ~SPI_0_MOSI_PIN;
-            SPI_0_SCK_PORT->PIO_ABSR &= ~SPI_0_SCK_PIN;
-
-            break;
-#endif /* SPI_0_EN */
-        default:
-            return -1;
-    }
-
-    return 0;
-}
-
-int spi_acquire(spi_t dev)
-{
-    if ((unsigned int)dev >= SPI_NUMOF) {
+    if ((bus >= SPI_NUMOF) || (cs == SPI_CS_UNDEF)) {
         return -1;
     }
-    mutex_lock(&locks[dev]);
-    return 0;
+
+    gpio_init(spi_config[bus].clk, GPIO_OUT);
+    gpio_init(spi_config[bus].mosi, GPIO_OUT);
+    gpio_init(spi_config[bus].miso, GPIO_IN);
+    gpio_init_mux(spi_config[bus].clk, spi_config[bus].mux);
+    gpio_init_mux(spi_config[bus].mosi, spi_config[bus].mux);
+    gpio_init_mux(spi_config[bus].miso, spi_config[bus].mux);
+
+    gpio_init((gpio_t)cs, GPIO_OUT);
+    gpio_set((gpio_t)cs);
 }
 
-int spi_release(spi_t dev)
+int spi_acquire(spi_t bus, spi_mode_t mode, spi_clk_t clk, spi_cs_t cs)
 {
-    if ((unsigned int)dev >= SPI_NUMOF) {
+    if ((bus >= SPI_NUMOF) || (cs == SPI_CS_UNDEF)) {
         return -1;
     }
-    mutex_unlock(&locks[dev]);
+
+    /* lock bus */
+    mutex_lock(&locks[bus]);
+    /* enable SPI device clock */
+    clk_en(bus);
+    /* set mode and speed */
+    dev(bus)->SPI_CSR[0] = (clk | mode);
+    dev(bus)->SPI_MR = (SPI_MR_MSTR | SPI_MR_MODFDIS);
+    dev(bus)->SPI_CR |= SPI_CR_SPIEN;
+
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_release(spi_t bus)
 {
-    Spi *spi_port;
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            break;
-#endif /* SPI_0_EN */
-        default:
-            return -1;
-    }
-
-    while (!(spi_port->SPI_SR & SPI_SR_TDRE)) {}
-
-    spi_port->SPI_TDR = SPI_TDR_TD(out);
-
-    while (!(spi_port->SPI_SR & SPI_SR_RDRF)) {}
-
-    *in = spi_port->SPI_RDR & SPI_RDR_RD_Msk;
-
-    return 1;
+    dev(bus)->SPI_CR = 0;
+    clk_dis(bus);
+    mutex_unlock(&locks[bus]);
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont,
+                       uint8_t out, uint8_t *in)
 {
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            SPI_0_DEV->SPI_TDR = SPI_TDR_TD(reset_val);
-            break;
-#endif /* SPI_0_EN */
-    }
+    spi_transfer_bytes(bus, cs, cont, &out, in, 1);
 }
 
-static inline void irq_handler_transfer(Spi *spi, spi_t dev)
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        uint8_t *out, uint8_t *in, size_t len)
 {
-    if (spi->SPI_SR & SPI_SR_RDRF) {
-        char data;
-        data = spi->SPI_RDR & SPI_RDR_RD_Msk;
-        data = spi_config[dev].cb(data);
-        spi->SPI_TDR = SPI_TDR_TD(data);
+    gpio_clear((gpio_t)cs);
+
+    for (size_t i = 0; i < len; i++) {
+        uint8_t tmp = (out) ? out[i] : 0;
+
+        while (!(dev(bus)->SPI_SR & SPI_SR_TDRE));
+        dev(bus)->SPI_TDR = tmp;
+        while (!(dev(bus)->SPI_SR & SPI_SR_RDRF));
+        tmp = (uint8_t)dev(bus)->SPI_RDR;
+
+        if (in) {
+            in[i] = tmp;
+        }
     }
 
-    /* See if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
+    if (!cont) {
+        gpio_set((gpio_t)cs);
     }
 }
 
-#if SPI_0_EN
-void SPI_0_IRQ_HANDLER(void)
+void spi_transfer_reg(spi_t bus, spi_cs_t cs,
+                      uint8_t reg, uint8_t out, uint8_t *in)
 {
-    if (SPI_0_DEV->SPI_SR & SPI_SR_RDRF) {
-        irq_handler_transfer(SPI_0_DEV, SPI_0);
-    }
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, &out, in, 1);
 }
-#endif
 
-#endif /* SPI_NUMOF */
+void spi_transfer_regs(spi_t bus, spi_cs_t cs,
+                       uint8_t reg, uint8_t *out, uint8_t *in, size_t len)
+{
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, out, in, len);
+}

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -86,8 +86,8 @@ typedef struct {
     gpio_t rx_pin;          /**< pin used for RX */
     gpio_t tx_pin;          /**< pin used for TX */
     gpio_mux_t mux;         /**< alternative function for pins */
-    sercom_rxpad_t rx_pad;  /**< pad selection for RX */
-    sercom_uart_txpad_t tx_pad; /**< pad selection for TX */
+    uart_rxpad_t rx_pad;    /**< pad selection for RX line */
+    uart_txpad_t tx_pad;    /**< pad selection for TX line */
 } uart_conf_t;
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -19,6 +19,8 @@
 #ifndef CPU_PERIPH_H
 #define CPU_PERIPH_H
 
+#include <limits.h>
+
 #include "periph_cpu_common.h"
 
 #ifdef __cplusplus
@@ -44,6 +46,13 @@ enum {
  */
 #define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
 
+/**
+ * @brief   Override SPI hardware chip select macro
+ *
+ * As of now, we do not support HW CS, so we always set it to a fixed value
+ */
+#define SPI_HWCS(x)     (UINT_MAX - 1)
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
@@ -58,6 +67,33 @@ typedef enum {
     GPIO_OD    = 0xfe,                  /**< not supported by HW */
     GPIO_OD_PU = 0xff                   /**< not supported by HW */
 } gpio_mode_t;
+/** @} */
+
+/**
+ * @brief   Override SPI modes
+ * @{
+ */
+#define HAVE_SPI_MODE_T
+typedef enum {
+    SPI_MODE_0 = 0x0,       /**< CPOL=0, CPHA=0 */
+    SPI_MODE_1 = 0x1,       /**< CPOL=0, CPHA=1 */
+    SPI_MODE_2 = 0x2,       /**< CPOL=1, CPHA=0 */
+    SPI_MODE_3 = 0x3        /**< CPOL=1, CPHA=1 */
+} spi_mode_t;
+/** @} */
+
+/**
+ * @brief   Override SPI clock speed values
+ * @{
+ */
+#define HAVE_SPI_CLK_T
+typedef enum {
+    SPI_CLK_100KHZ =   100000U, /**< drive the SPI bus with 100KHz */
+    SPI_CLK_400KHZ =   400000U, /**< drive the SPI bus with 400KHz */
+    SPI_CLK_1MHZ   =  1000000U, /**< drive the SPI bus with 1MHz */
+    SPI_CLK_5MHZ   =  5000000U, /**< drive the SPI bus with 5MHz */
+    SPI_CLK_10MHZ  = 10000000U  /**< drive the SPI bus with 10MHz */
+} spi_clk_t;
 /** @} */
 #endif /* ndef DOXYGEN */
 
@@ -91,13 +127,28 @@ typedef struct {
 } uart_conf_t;
 
 /**
+ * @brief   SPI device configuration
+ */
+typedef struct {
+    SercomSpi *dev;         /**< pointer to the used SPI device */
+    gpio_t miso_pin;        /**< used MISO pin */
+    gpio_t mosi_pin;        /**< used MOSI pin */
+    gpio_t clk_pin;         /**< used CLK pin */
+    gpio_mux_t miso_mux;    /**< alternate function for MISO pin (mux) */
+    gpio_mux_t mosi_mux;    /**< alternate function for MOSI pin (mux) */
+    gpio_mux_t clk_mux;     /**< alternate function for CLK pin (mux) */
+    spi_misopad_t miso_pad; /**< pad to use for MISO line */
+    spi_mosipad_t mosi_pad; /**< pad to use for MOSI and CLK line */
+} spi_conf_t;
+
+/**
  * @brief   Return the numeric id of a SERCOM device derived from its address
  *
  * @param[in] sercom    SERCOM device
  *
  * @return              numeric id of the given SERCOM device
  */
-static inline int _sercom_id(SercomUsart *sercom)
+static inline int sercom_id(void *sercom)
 {
     return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
 }

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -67,8 +67,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     gpio_mux_t mux_sclk = 0;
     gpio_mux_t mux_miso = 0;
     gpio_mux_t mux_mosi = 0;
-    sercom_spi_txpad_t  dopo = 0;
-    sercom_rxpad_t      dipo = 0;
+    spi_mosipad_t mosi_pad = 0;
+    spi_misopad_t miso_pad = 0;
     uint32_t   cpha = 0;
     uint32_t   cpol = 0;
     uint32_t   f_baud = 0;
@@ -129,8 +129,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         mux_miso = SPI_0_MISO_MUX;
         pin_mosi = SPI_0_MOSI;
         mux_mosi = SPI_0_MOSI_MUX;
-        dopo = SPI_0_MOSI_PAD;
-        dipo = SPI_0_MISO_PAD;
+        mosi_pad = SPI_0_MOSI_PAD;
+        miso_pad = SPI_0_MISO_PAD;
         break;
 #endif
 #if SPI_1_EN
@@ -143,8 +143,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         mux_miso = SPI_1_MISO_MUX;
         pin_mosi = SPI_1_MOSI;
         mux_mosi = SPI_1_MOSI_MUX;
-        dopo = SPI_1_MOSI_PAD;
-        dipo = SPI_1_MISO_PAD;
+        mosi_pad = SPI_1_MOSI_PAD;
+        miso_pad = SPI_1_MISO_PAD;
         break;
 #endif
     default:
@@ -191,8 +191,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 
     spi_dev->BAUD.bit.BAUD = (uint8_t) (((uint32_t)CLOCK_CORECLOCK) / (2 * f_baud) - 1); /* Synchronous mode*/
 
-    spi_dev->CTRLA.reg |= SERCOM_SPI_CTRLA_DOPO(dopo)
-                       |  SERCOM_SPI_CTRLA_DIPO(dipo)
+    spi_dev->CTRLA.reg |= SERCOM_SPI_CTRLA_DOPO(mosi_pad)
+                       |  SERCOM_SPI_CTRLA_DIPO(miso_pad)
                        |  cpha
                        |  cpol;
     while (spi_dev->SYNCBUSY.reg) {}	// ???? not needed

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -86,12 +86,12 @@ static int init_base(uart_t uart, uint32_t baudrate)
     /* reset the UART device */
     dev->CTRLA.reg = SERCOM_USART_CTRLA_SWRST;
     while (dev->SYNCBUSY.reg & SERCOM_USART_SYNCBUSY_SWRST) {}
-    /* set asynchronous mode w/o parity, LSB first, PADn to TX, PADn to RX and
-     * use internal clock */
+    /* set asynchronous mode w/o parity, LSB first, TX and RX pad as specified
+     * by the board in the periph_conf.h, x16 sampling and use internal clock */
     dev->CTRLA.reg = (SERCOM_USART_CTRLA_DORD |
+                      SERCOM_USART_CTRLA_SAMPR(0x1) |
                       SERCOM_USART_CTRLA_TXPO(uart_config[uart].tx_pad) |
                       SERCOM_USART_CTRLA_RXPO(uart_config[uart].rx_pad) |
-                      SERCOM_USART_CTRLA_SAMPR(0x1) |			// 1: x16 sample rate
                       SERCOM_USART_CTRLA_MODE_USART_INT_CLK);
     /* set baudrate */
     dev->BAUD.FRAC.FP = (baud % 10);

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -59,7 +59,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     uart_ctx[uart].arg = arg;
     /* configure interrupts and enable RX interrupt */
     _uart(uart)->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
-    NVIC_EnableIRQ(SERCOM0_IRQn + _sercom_id(_uart(uart)));
+    NVIC_EnableIRQ(SERCOM0_IRQn + sercom_id(_uart(uart)));
     return 0;
 }
 
@@ -114,18 +114,18 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
 void uart_poweron(uart_t uart)
 {
-    PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << _sercom_id(_uart(uart)));
+    PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << sercom_id(_uart(uart)));
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
                          GCLK_CLKCTRL_GEN_GCLK0 |
-                         (SERCOM0_GCLK_ID_CORE + _sercom_id(_uart(uart))) <<
+                         (SERCOM0_GCLK_ID_CORE + sercom_id(_uart(uart))) <<
                           GCLK_CLKCTRL_ID_Pos);
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 }
 
 void uart_poweroff(uart_t uart)
 {
-    PM->APBCMASK.reg &= ~(PM_APBCMASK_SERCOM0 << _sercom_id(_uart(uart)));
-    GCLK->CLKCTRL.reg = ((SERCOM0_GCLK_ID_CORE + _sercom_id(_uart(uart))) <<
+    PM->APBCMASK.reg &= ~(PM_APBCMASK_SERCOM0 << sercom_id(_uart(uart)));
+    GCLK->CLKCTRL.reg = ((SERCOM0_GCLK_ID_CORE + sercom_id(_uart(uart))) <<
                           GCLK_CLKCTRL_ID_Pos);
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 }

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -2,4 +2,5 @@ export CPU_ARCH = cortex-m4f
 export CPU_FAM  = stm32f4
 
 include $(RIOTCPU)/stm32_common/Makefile.include
+
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -38,7 +38,7 @@ extern "C" {
  * @brief declare needed generic SPI functions
  * @{
  */
-#define PERIPH_SPI_NEEDS_TRANSFER_BYTES
+#define PERIPH_SPI_NEEDS_TRANSFER_BYTE
 #define PERIPH_SPI_NEEDS_TRANSFER_REG
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -87,6 +87,14 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
+/*
+ * @brief   Peripheral buses
+ */
+enum {
+    BUS_APB1 = 1,
+    BUS_APB2 = 0
+};
+
 /**
  * @brief   Available ports on the STM32F4 family
  */
@@ -156,6 +164,19 @@ typedef struct {
     gpio_t pin;             /**< pin connected to the line */
     uint8_t chan;           /**< DAC device used for this line */
 } dac_conf_t;
+
+/**
+ * @brief   Structure for SPI configuration data
+ */
+typedef struct {
+    SPI_TypeDef *dev;       /**< SPI device base register address */
+    gpio_t mosi_pin;        /**< MOSI pin */
+    gpio_t miso_pin;        /**< MISO pin */
+    gpio_t sclk_pin;        /**< SCLK pin */
+    gpio_af_t af;           /**< pin alternate function */
+    uint8_t abpbus;         /**< APB bus, 0 := APB1, 1:= APB2 */
+    uint32_t rccmask;         /**< bit in the RCC peripheral enable register */
+} spi_conf_t;
 
 /**
  * @brief   Configure the alternate function for the given pin

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -138,16 +138,15 @@ void spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont,
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                         uint8_t *out, uint8_t *in, size_t len)
 {
-    uint8_t tmp;
-
-    dev(bus)->CR1 |= (SPI_CR1_SPE);     /* this pull the HW CS line low */
+    dev(bus)->CR1 |= (SPI_CR1_SPE);     /* this pulls the HW CS line low */
     if (cs != HWCS_LINE) {
         gpio_clear((gpio_t)cs);
     }
 
     for (size_t i = 0; i < len; i++) {
+        uint8_t tmp = (out) ? out[i] : 0;
         while (!(dev(bus)->SR & SPI_SR_TXE));
-        dev(bus)->DR = out[i];
+        dev(bus)->DR = tmp;
         while (!(dev(bus)->SR & SPI_SR_RXNE));
         tmp = dev(bus)->DR;
         if (in) {

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -29,38 +29,13 @@
 #include "thread.h"
 #include "sched.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
-
 /**
- * @brief Data-structure holding the state for a SPI device
+ * @brief   The STM32F4 only has one hardware chip select line
  */
-typedef struct {
-    char(*cb)(char data);
-} spi_state_t;
-
-static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev);
-
-/**
- * @brief Reserve memory for saving the SPI device's state
- */
-static spi_state_t spi_config[SPI_NUMOF];
-
-/* static bus div mapping */
-static const uint8_t spi_bus_div_map[SPI_NUMOF] = {
-#if SPI_0_EN
-    [SPI_0] = SPI_0_BUS_DIV,
-#endif
-#if SPI_1_EN
-    [SPI_1] = SPI_1_BUS_DIV,
-#endif
-#if SPI_2_EN
-    [SPI_2] = SPI_2_BUS_DIV,
-#endif
-};
+#define HWCS_LINE           (0)
 
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
@@ -77,379 +52,129 @@ static mutex_t locks[] =  {
 #endif
 };
 
-int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
+static inline SPI_TypeDef *dev(spi_t bus)
 {
-    uint8_t speed_devider;
-    SPI_TypeDef *spi_port;
-
-    switch (speed) {
-        case SPI_SPEED_100KHZ:
-            return -2;          /* not possible for stm32f4, APB2 minimum is 328 kHz */
-            break;
-        case SPI_SPEED_400KHZ:
-            speed_devider = 0x05 + spi_bus_div_map[dev];  /* makes 656 kHz */
-            break;
-        case SPI_SPEED_1MHZ:
-            speed_devider = 0x04 + spi_bus_div_map[dev];  /* makes 1.3 MHz */
-            break;
-        case SPI_SPEED_5MHZ:
-            speed_devider = 0x02 + spi_bus_div_map[dev];  /* makes 5.3 MHz */
-            break;
-        case SPI_SPEED_10MHZ:
-            speed_devider = 0x01 + spi_bus_div_map[dev];  /* makes 10.5 MHz */
-            break;
-        default:
-            return -1;
-    }
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            /* enable clocks */
-            SPI_0_CLKEN();
-            SPI_0_SCK_PORT_CLKEN();
-            SPI_0_MISO_PORT_CLKEN();
-            SPI_0_MOSI_PORT_CLKEN();
-            break;
-#endif /* SPI_0_EN */
-#if SPI_1_EN
-        case SPI_1:
-            spi_port = SPI_1_DEV;
-            /* enable clocks */
-            SPI_1_CLKEN();
-            SPI_1_SCK_PORT_CLKEN();
-            SPI_1_MISO_PORT_CLKEN();
-            SPI_1_MOSI_PORT_CLKEN();
-            break;
-#endif /* SPI_1_EN */
-#if SPI_2_EN
-        case SPI_2:
-            spi_port = SPI_2_DEV;
-            /* enable clocks */
-            SPI_2_CLKEN();
-            SPI_2_SCK_PORT_CLKEN();
-            SPI_2_MISO_PORT_CLKEN();
-            SPI_2_MOSI_PORT_CLKEN();
-            break;
-#endif /* SPI_2_EN */
-        default:
-            return -2;
-    }
-
-    /* configure SCK, MISO and MOSI pin */
-    spi_conf_pins(dev);
-
-    /**************** SPI-Init *****************/
-    spi_port->I2SCFGR &= ~(SPI_I2SCFGR_I2SMOD);/* Activate the SPI mode (Reset I2SMOD bit in I2SCFGR register) */
-    spi_port->CR1 = 0;
-    spi_port->CR2 = 0;
-    /* the NSS (chip select) is managed purely by software */
-    spi_port->CR1 |= SPI_CR1_SSM | SPI_CR1_SSI;
-    spi_port->CR1 |= (speed_devider << 3);  /* Define serial clock baud rate. 001 leads to f_PCLK/4 */
-    spi_port->CR1 |= (SPI_CR1_MSTR);  /* 1: master configuration */
-    spi_port->CR1 |= (conf);
-    /* enable SPI */
-    spi_port->CR1 |= (SPI_CR1_SPE);
-    return 0;
+    return spi_config[bus].dev;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+static inline void clk_en(spi_t bus)
 {
-    SPI_TypeDef *spi_port;
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            /* enable clocks */
-            SPI_0_CLKEN();
-            SPI_0_SCK_PORT_CLKEN();
-            SPI_0_MISO_PORT_CLKEN();
-            SPI_0_MOSI_PORT_CLKEN();
-            /* configure interrupt channel */
-            NVIC_SetPriority(SPI_0_IRQ, SPI_IRQ_PRIO); /* set SPI interrupt priority */
-            NVIC_EnableIRQ(SPI_0_IRQ); /* set SPI interrupt priority */
-            break;
-#endif /* SPI_0_EN */
-#if SPI_1_EN
-        case SPI_1:
-            spi_port = SPI_1_DEV;
-            /* enable clocks */
-            SPI_1_CLKEN();
-            SPI_1_SCK_PORT_CLKEN();
-            SPI_1_MISO_PORT_CLKEN();
-            SPI_1_MOSI_PORT_CLKEN();
-            /* configure interrupt channel */
-            NVIC_SetPriority(SPI_1_IRQ, SPI_IRQ_PRIO);
-            NVIC_EnableIRQ(SPI_1_IRQ);
-            break;
-#endif /* SPI_1_EN */
-#if SPI_2_EN
-        case SPI_2:
-            spi_port = SPI_2_DEV;
-            /* enable clocks */
-            SPI_2_CLKEN();
-            SPI_2_SCK_PORT_CLKEN();
-            SPI_2_MISO_PORT_CLKEN();
-            SPI_2_MOSI_PORT_CLKEN();
-            /* configure interrupt channel */
-            NVIC_SetPriority(SPI_2_IRQ, SPI_IRQ_PRIO);
-            NVIC_EnableIRQ(SPI_2_IRQ);
-            break;
-#endif /* SPI_2_EN */
-        default:
-            return -1;
-    }
-
-    /* configure sck, miso and mosi pin */
-    spi_conf_pins(dev);
-
-    /***************** SPI-Init *****************/
-    spi_port->I2SCFGR &= ~(SPI_I2SCFGR_I2SMOD);
-    spi_port->CR1 = 0;
-    spi_port->CR2 = 0;
-    /* enable RXNEIE flag to enable rx buffer not empty interrupt */
-    spi_port->CR2 |= (SPI_CR2_RXNEIE); /*1:not masked */
-    spi_port->CR1 |= (conf);
-     /* the NSS (chip select) is managed by software and NSS is low (slave enabled) */
-    spi_port->CR1 |= SPI_CR1_SSM;
-    /* set callback */
-    spi_config[dev].cb = cb;
-    /* enable SPI device */
-    spi_port->CR1 |= SPI_CR1_SPE;
-    return 0;
-}
-
-int spi_conf_pins(spi_t dev)
-{
-    GPIO_TypeDef *port[3];
-    int pin[3], af[3];
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            port[0] = SPI_0_SCK_PORT;
-            pin[0] = SPI_0_SCK_PIN;
-            af[0] = SPI_0_SCK_AF;
-            port[1] = SPI_0_MOSI_PORT;
-            pin[1] = SPI_0_MOSI_PIN;
-            af[1] = SPI_0_MOSI_AF;
-            port[2] = SPI_0_MISO_PORT;
-            pin[2] = SPI_0_MISO_PIN;
-            af[2] = SPI_0_MISO_AF;
-            break;
-#endif /* SPI_0_EN */
-#if SPI_1_EN
-        case SPI_1:
-            port[0] = SPI_1_SCK_PORT;
-            pin[0] = SPI_1_SCK_PIN;
-            af[0] = SPI_1_SCK_AF;
-            port[1] = SPI_1_MOSI_PORT;
-            pin[1] = SPI_1_MOSI_PIN;
-            af[1] = SPI_1_MOSI_AF;
-            port[2] = SPI_1_MISO_PORT;
-            pin[2] = SPI_1_MISO_PIN;
-            af[2] = SPI_1_MISO_AF;
-            break;
-#endif /* SPI_1_EN */
-#if SPI_2_EN
-        case SPI_2:
-            port[0] = SPI_2_SCK_PORT;
-            pin[0] = SPI_2_SCK_PIN;
-            af[0] = SPI_2_SCK_AF;
-            port[1] = SPI_2_MOSI_PORT;
-            pin[1] = SPI_2_MOSI_PIN;
-            af[1] = SPI_2_MOSI_AF;
-            port[2] = SPI_2_MISO_PORT;
-            pin[2] = SPI_2_MISO_PIN;
-            af[2] = SPI_2_MISO_AF;
-            break;
-#endif /* SPI_2_EN */
-        default:
-            return -1;
-    }
-
-    /***************** GPIO-Init *****************/
-    for (int i = 0; i < 3; i++) {
-        /* Set GPIOs to AF mode */
-        port[i]->MODER &= ~(3 << (2 * pin[i]));
-        port[i]->MODER |= (2 << (2 * pin[i]));
-        /* Set speed */
-        port[i]->OSPEEDR &= ~(3 << (2 * pin[i]));
-        port[i]->OSPEEDR |= (3 << (2 * pin[i]));
-        /* Set to push-pull configuration */
-        port[i]->OTYPER &= ~(1 << pin[i]);
-        /* Configure push-pull resistors */
-        port[i]->PUPDR &= ~(3 << (2 * pin[i]));
-        port[i]->PUPDR |= (2 << (2 * pin[i]));
-        /* Configure GPIOs for the SPI alternate function */
-        int hl = (pin[i] < 8) ? 0 : 1;
-        port[i]->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
-        port[i]->AFR[hl] |= (af[i] << ((pin[i] - (hl * 8)) * 4));
-    }
-
-    return 0;
-}
-
-int spi_acquire(spi_t dev)
-{
-    if ((unsigned int)dev >= SPI_NUMOF) {
-        return -1;
-    }
-    mutex_lock(&locks[dev]);
-    return 0;
-}
-
-int spi_release(spi_t dev)
-{
-    if ((unsigned int)dev >= SPI_NUMOF) {
-        return -1;
-    }
-    mutex_unlock(&locks[dev]);
-    return 0;
-}
-
-int spi_transfer_byte(spi_t dev, char out, char *in)
-{
-    SPI_TypeDef *spi_port;
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            spi_port = SPI_1_DEV;
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            spi_port = SPI_2_DEV;
-            break;
-#endif
-        default:
-            return -1;
-    }
-
-    while (!(spi_port->SR & SPI_SR_TXE)) {}
-    spi_port->DR = out;
-
-    while (!(spi_port->SR & SPI_SR_RXNE)) {}
-
-    if (in != NULL) {
-        *in = spi_port->DR;
+    if (spi_config[bus].abpbus == BUS_APB1) {
+        RCC->APB1ENR |= (spi_config[bus].rccmask);
     }
     else {
-        spi_port->DR;
-    }
-
-    return 1;
-}
-
-void spi_transmission_begin(spi_t dev, char reset_val)
-{
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            SPI_0_DEV->DR = reset_val;
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            SPI_1_DEV->DR = reset_val;
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            SPI_2_DEV->DR = reset_val;
-            break;
-#endif
+        RCC->APB2ENR |= (spi_config[bus].rccmask);
     }
 }
 
-void spi_poweron(spi_t dev)
+static inline void clk_dis(spi_t bus)
 {
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            SPI_0_CLKEN();
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            SPI_1_CLKEN();
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            SPI_2_CLKEN();
-            break;
-#endif
+    if (spi_config[bus].abpbus == BUS_APB1) {
+        RCC->APB1ENR &= ~(spi_config[bus].rccmask);
+    }
+    else {
+        RCC->APB2ENR &= ~(spi_config[bus].rccmask);
     }
 }
 
-void spi_poweroff(spi_t dev)
+int spi_init(spi_t bus, spi_cs_t cs)
 {
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            while (SPI_0_DEV->SR & SPI_SR_BSY) {}
-            SPI_0_CLKDIS();
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            while (SPI_1_DEV->SR & SPI_SR_BSY) {}
-            SPI_1_CLKDIS();
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            while (SPI_2_DEV->SR & SPI_SR_BSY) {}
-            SPI_2_CLKDIS();
-            break;
-#endif
+    if (bus >= SPI_NUMOF) {
+        return -1;
+    }
+
+    gpio_init(spi_config[bus].mosi_pin, GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_init(spi_config[bus].miso_pin, GPIO_DIR_IN, GPIO_NOPULL);
+    gpio_init(spi_config[bus].sclk_pin, GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].af);
+    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].af);
+    gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].af);
+
+    if (cs == HWCS_LINE) {
+        gpio_init((gpio_t)cs, GPIO_DIR_OUT, GPIO_NOPULL);
+        gpio_init_af((gpio_t)cs, spi_config[bus].af);
+    }
+    else {
+        gpio_init((gpio_t)cs, GPIO_DIR_OUT, GPIO_NOPULL);
+        gpio_set((gpio_t)cs);
+    }
+
+    return 0;
+}
+
+int spi_acquire(spi_t bus, spi_mode_t mode, spi_clk_t clk, spi_cs_t cs)
+{
+    /* check device and clock speed for validity */
+    if (bus >= SPI_NUMOF || clk > 0x0f) {
+        return -1;
+    }
+
+    /* lock bus */
+    mutex_lock(&locks[bus]);
+    /* enable SPI device clock */
+    clk_en(bus);
+    /* enable device */
+    dev(bus)->CR1 = (((clk + spi_config[bus].abpbus) << 3) | mode | SPI_CR1_MSTR);
+    if (cs != HWCS_LINE) {
+        dev(bus)->CR1 |= SPI_CR1_SSM | SPI_CR1_SSI;
+    }
+    return 0;
+}
+
+void spi_release(spi_t bus)
+{
+    /* disable device */
+    dev(bus)->CR1 = 0;
+    clk_dis(bus);
+    mutex_unlock(&locks[bus]);
+}
+
+void spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont,
+                       uint8_t out, uint8_t *in)
+{
+    spi_transfer_bytes(bus, cs, cont, &out, in, 1);
+}
+
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        uint8_t *out, uint8_t *in, size_t len)
+{
+    uint8_t tmp;
+
+    dev(bus)->CR1 |= (SPI_CR1_SPE);     /* this pull the HW CS line low */
+    if (cs != HWCS_LINE) {
+        gpio_clear((gpio_t)cs);
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        while (!(dev(bus)->SR & SPI_SR_TXE));
+        dev(bus)->DR = out[i];
+        while (!(dev(bus)->SR & SPI_SR_RXNE));
+        tmp = dev(bus)->DR;
+        if (in) {
+            in[i] = tmp;
+        }
+    }
+
+    if (!cont) {
+        if (cs != HWCS_LINE) {
+            gpio_set((gpio_t)cs);
+        }
+        else {
+            dev(bus)->CR1 &= ~(SPI_CR1_SPE);    /* pull HW CS line high */
+        }
     }
 }
 
-static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
+void spi_transfer_reg(spi_t bus, spi_cs_t cs,
+                      uint8_t reg, uint8_t out, uint8_t *in)
 {
-
-    if (spi->SR & SPI_SR_RXNE) {
-        char data;
-        data = spi->DR;
-        data = spi_config[dev].cb(data);
-        spi->DR = data;
-    }
-    /* see if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, &out, in, 1);
 }
 
-#if SPI_0_EN
-void SPI_0_IRQ_HANDLER(void)
+void spi_transfer_regs(spi_t bus, spi_cs_t cs,
+                       uint8_t reg, uint8_t *out, uint8_t *in, size_t len)
 {
-    irq_handler_transfer(SPI_0_DEV, SPI_0);
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, out, in, len);
 }
-#endif
-
-#if SPI_1_EN
-void SPI_1_IRQ_HANDLER(void)
-{
-    irq_handler_transfer(SPI_1_DEV, SPI_1);
-}
-#endif
-
-#if SPI_2_EN
-void SPI_2_IRQ_HANDLER(void)
-{
-    irq_handler_transfer(SPI_2_DEV, SPI_2);
-}
-#endif
-
-#endif /* SPI_NUMOF */

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -45,8 +45,8 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
     dev->idle_state = AT86RF2XX_STATE_TRX_OFF;
     dev->state = AT86RF2XX_STATE_SLEEP;
     dev->pending_tx = 0;
-    /* initialise SPI */
-    spi_init_master(dev->params.spi, SPI_CONF_FIRST_RISING, params->spi_speed);
+    /* chip select line */
+    spi_init_cs(dev->params.spi, (spi_cs_t)dev->params.cs_pin);
 }
 
 void at86rf2xx_reset(at86rf2xx_t *dev)

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -28,32 +28,35 @@
 #include "at86rf2xx_internal.h"
 #include "at86rf2xx_registers.h"
 
+#define SPIDEV          (dev->params.spi)
+#define CSPIN           (dev->params.cs_pin)
+
+static inline void getbus(const at86rf2xx_t *dev)
+{
+    spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk);
+}
+
 void at86rf2xx_reg_write(const at86rf2xx_t *dev,
                          const uint8_t addr,
                          const uint8_t value)
 {
-    spi_acquire(dev->params.spi);
-    gpio_clear(dev->params.cs_pin);
-    spi_transfer_reg(dev->params.spi,
-                     AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_WRITE | addr,
-                     value, 0);
-    gpio_set(dev->params.cs_pin);
-    spi_release(dev->params.spi);
+    uint8_t reg = (AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_WRITE | addr);
+
+    getbus(dev);
+    spi_transfer_reg(SPIDEV, CSPIN, reg, value);
+    spi_release(SPIDEV);
 }
 
 uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr)
 {
-    char value;
+    uint8_t reg = (AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_READ | addr);
+    uint8_t value;
 
-    spi_acquire(dev->params.spi);
-    gpio_clear(dev->params.cs_pin);
-    spi_transfer_reg(dev->params.spi,
-                     AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_READ | addr,
-                     0, &value);
-    gpio_set(dev->params.cs_pin);
-    spi_release(dev->params.spi);
+    getbus(dev);
+    value = spi_transfer_reg(SPIDEV, CSPIN, reg, 0);
+    spi_release(SPIDEV);
 
-    return (uint8_t)value;
+    return value;
 }
 
 void at86rf2xx_sram_read(const at86rf2xx_t *dev,
@@ -61,14 +64,13 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev,
                          uint8_t *data,
                          const size_t len)
 {
-    spi_acquire(dev->params.spi);
-    gpio_clear(dev->params.cs_pin);
-    spi_transfer_reg(dev->params.spi,
-                     AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ,
-                     (char)offset, NULL);
-    spi_transfer_bytes(dev->params.spi, NULL, (char *)data, len);
-    gpio_set(dev->params.cs_pin);
-    spi_release(dev->params.spi);
+    uint8_t reg = (AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ);
+
+    getbus(dev);
+    spi_transfer_byte(SPIDEV, CSPIN, true, reg);
+    spi_transfer_byte(SPIDEV, CSPIN, true, offset);
+    spi_transfer_bytes(SPIDEV, CSPIN, false, NULL, data, len);
+    spi_release(SPIDEV);
 }
 
 void at86rf2xx_sram_write(const at86rf2xx_t *dev,
@@ -76,36 +78,35 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev,
                           const uint8_t *data,
                           const size_t len)
 {
-    spi_acquire(dev->params.spi);
-    gpio_clear(dev->params.cs_pin);
-    spi_transfer_reg(dev->params.spi,
-                     AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE,
-                     (char)offset, NULL);
-    spi_transfer_bytes(dev->params.spi, (char *)data, NULL, len);
-    gpio_set(dev->params.cs_pin);
-    spi_release(dev->params.spi);
+    uint8_t reg = (AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE);
+
+    getbus(dev);
+    spi_transfer_byte(SPIDEV, CSPIN, true, reg);
+    spi_transfer_byte(SPIDEV, CSPIN, true, offset);
+    spi_transfer_bytes(SPIDEV, CSPIN, false, data, NULL, len);
+    spi_release(SPIDEV);
 }
 
 void at86rf2xx_fb_start(const at86rf2xx_t *dev)
 {
-    spi_acquire(dev->params.spi);
-    gpio_clear(dev->params.cs_pin);
-    spi_transfer_byte(dev->params.spi,
-                      AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ,
-                      NULL);
+    uint8_t reg = AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ;
+
+    getbus(dev);
+    spi_transfer_byte(SPIDEV, CSPIN, true, reg);
 }
 
 void at86rf2xx_fb_read(const at86rf2xx_t *dev,
                        uint8_t *data,
                        const size_t len)
 {
-    spi_transfer_bytes(dev->params.spi, NULL, (char *)data, len);
+    spi_transfer_bytes(SPIDEV, CSPIN, true, NULL, data, len);
 }
 
 void at86rf2xx_fb_stop(const at86rf2xx_t *dev)
 {
-    gpio_set(dev->params.cs_pin);
-    spi_release(dev->params.spi);
+    /* transfer one byte (which we ignore) to release the chip select */
+    spi_transfer_byte(SPIDEV, CSPIN, false, 1);
+    spi_release(SPIDEV);
 }
 
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev)

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -143,8 +143,8 @@ extern "C" {
  */
 typedef struct at86rf2xx_params {
     spi_t spi;              /**< SPI bus the device is connected to */
-    spi_speed_t spi_speed;  /**< SPI speed to use */
-    gpio_t cs_pin;          /**< GPIO pin connected to chip select */
+    spi_clk_t spi_clk;      /**< SPI clock speed to use */
+    spi_cs_t cs_pin;        /**< GPIO pin connected to chip select */
     gpio_t int_pin;         /**< GPIO pin connected to the interrupt pin */
     gpio_t sleep_pin;       /**< GPIO pin connected to the sleep pin */
     gpio_t reset_pin;       /**< GPIO pin connected to the reset pin */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -129,7 +129,6 @@ typedef enum {
  */
 int spi_init_pins(spi_t dev, spi_cs_t cs);
 
-
 /**
  * @brief Get mutually exclusive access to the given SPI bus
  *

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -181,9 +181,31 @@ typedef enum {
  * Errors (e.g. invalid @p bus parameter) are not signaled through a return
  * value, but should be signaled using the assert() function internally.
  *
+ * @note    This function MUST not be called more than once per bus!
+ *
  * @param[in] bus       SPI device to initialize
  */
 void spi_init(spi_t bus);
+
+/**
+ * @brief   Initialize the used SPI bus pins, i.e. MISO, MOSI, and CLK
+ *
+ *
+ * After calling spi_init, the pins must be initialized (i.e. spi_init is
+ * calling) this function internally. In normal cases, this function will not be
+ * used. But there are some devices (e.g. CC110x), that use SPI bus lines also
+ * for other purposes and need the option to dynamically re-configure one or
+ * more of the used pins. So they can take control over certain pins and return
+ * control back to the SPI driver using this function.
+ *
+ * The pins used are configured in the board's periph_conf.h.
+ *
+ * @param[in] bus       SPI device the pins are configure for
+ *
+ * @return              SPI_OK on success
+ * @return              SPI_NODEV on invalid device
+ */
+int spi_init_pins(spi_t bus);
 
 /**
  * @brief   Initialize the given chip select pin

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -219,6 +219,9 @@ int spi_init_pins(spi_t bus);
  * hardware chip select line `x` or the GPIO_PIN(x,y) macro for using any
  * GPIO pin for manual chip select.
  *
+ * @param[in] bus       SPI device that is used with the given CS line
+ * @param[in] cs        chip select pin to initialize
+ *
  * @return              SPI_OK on success
  * @return              SPI_NODEV on invalid device
  * @return              SPI_NOCS on invalid CS pin/line
@@ -237,7 +240,8 @@ int spi_init_cs(spi_t bus, spi_cs_t cs);
  *          valid (they are checked in spi_init and spi_init_cs before)
  *
  * @param[in] bus       SPI device to access
- * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in] cs        chip select pin/line to use, set to SPI_CS_UNDEF if chip
+ *                      select should not be handled by the SPI driver
  * @param[in] mode      mode to use for the new transaction
  * @param[in] clk       bus clock speed to use for the transaction
  *
@@ -261,7 +265,8 @@ void spi_release(spi_t bus);
  * @brief Transfer one byte on the given SPI bus
  *
  * @param[in] bus       SPI device to use
- * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in] cs        chip select pin/line to use, set to SPI_CS_UNDEF if chip
+ *                      select should not be handled by the SPI driver
  * @param[in] cont      if true, keep device selected after transfer
  * @param[in] out       byte to send out, set NULL if only receiving
  *
@@ -273,7 +278,8 @@ uint8_t spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont, uint8_t out);
  * @brief   Transfer a number bytes using the given SPI bus
  *
  * @param[in]  bus      SPI device to use
- * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in]  cs       chip select pin/line to use, set to SPI_CS_UNDEF if chip
+ *                      select should not be handled by the SPI driver
  * @param[in]  cont     if true, keep device selected after transfer
  * @param[in]  out      buffer to send data from, set NULL if only receiving
  * @param[out] in       buffer to read into, set NULL if only sending
@@ -289,7 +295,8 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
  * implement a register based access scheme.
  *
  * @param[in] bus       SPI device to use
- * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in]  cs       chip select pin/line to use, set to SPI_CS_UNDEF if chip
+ *                      select should not be handled by the SPI driver
  * @param[in] reg       register address to transfer data to/from
  * @param[in] out       byte to send, set NULL if only receiving data
  *
@@ -304,7 +311,8 @@ uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
  * implement a register based access scheme.
  *
  * @param[in]  bus      SPI device to use
- * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in]  cs       chip select pin/line to use, set to SPI_CS_UNDEF if chip
+ *                      select should not be handled by the SPI driver
  * @param[in]  reg      register address to transfer data to/from
  * @param[in]  out      buffer to send data from, set NULL if only receiving
  * @param[out] in       buffer to read into, set NULL if only sending

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -24,6 +24,12 @@
  * reflected by the cpi_cs_t type, which overloads the gpio_t type with platform
  * specific values for defining platform dependent hardware chip select lines.
  *
+ * Some devices have however very uncommon requirements on the usage and the
+ * timings of their chip select line. For those cases this interface allows to
+ * manage the chip select line manually from the user code (e.g. by calling
+ * gpio_set/clear explicitly) while deactivating the SPI driver internal chip
+ * select handling by passing @ref GPIO_UNDEF as CS parameter.
+ *
  * In the time, when the SPI bus is not used, the SPI unit should be in
  * low-power mode to save energy.
  *
@@ -206,9 +212,9 @@ int spi_init_cs(spi_t bus, spi_cs_t cs);
  * other transaction is complete (spi_relase was called).
  *
  * @param[in] bus       SPI device to access
+ * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
  * @param[in] mode      mode to use for the new transaction
  * @param[in] clk       bus clock speed to use for the transaction
- * @param[in] cs        chip select pin to use
  *
  * @return              SPI_OK on success
  * @return              SPI_NODEV on invalid device
@@ -232,7 +238,7 @@ void spi_release(spi_t bus);
  * @brief Transfer one byte on the given SPI bus
  *
  * @param[in] bus       SPI device to use
- * @param[in] cs        CS pin/line to use
+ * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
  * @param[in] cont      if true, keep device selected after transfer
  * @param[in] out       byte to send out, set NULL if only receiving
  *
@@ -244,7 +250,7 @@ uint8_t spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont, uint8_t out);
  * @brief   Transfer a number bytes using the given SPI bus
  *
  * @param[in]  bus      SPI device to use
- * @param[in]  cs       chip select pin/line to use
+ * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
  * @param[in]  cont     if true, keep device selected after transfer
  * @param[in]  out      buffer to send data from, set NULL if only receiving
  * @param[out] in       buffer to read into, set NULL if only sending
@@ -260,7 +266,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
  * implement a register based access scheme.
  *
  * @param[in]  bus      SPI device to use
- * @param[in]  cs       chip select pin/line to use
+ * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
  * @param[in] reg       Register address to transfer data to/from
  * @param[in] out       Byte to send, set NULL if only receiving data
  * @param[out] in       Byte to read, set NULL if only sending
@@ -276,7 +282,7 @@ uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
  * implement a register based access scheme.
  *
  * @param[in]  bus      SPI device to use
- * @param[in]  cs       chip select pin/line to use
+ * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
  * @param[in]  reg      register address to transfer data to/from
  * @param[in]  out      buffer to send data from, set NULL if only receiving
  * @param[out] in       buffer to read into, set NULL if only sending

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -29,8 +29,6 @@
 #include "periph_cpu.h"
 #include "periph_conf.h"
 #include "periph/gpio.h"
-/* TODO: remove once all platforms are ported to this interface */
-#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,14 +45,18 @@ extern "C" {
  * @brief   Define global value for undefined SPI device
  */
 #ifndef SPI_UNDEF
-#define SPI_UNDEF       (-1)
+#define SPI_UNDEF       (UINT_MAX)
 #endif
 
 /**
  * @brief   Default SPI chip select pin access macro
+ *
+ * UINT_MAX is the default value for GPIO_UNDEF, so we go one less here. This
+ * still gives us the highest possible chance not to collide with and valid
+ * GPIO_PIN(x,y) value.
  */
 #ifndef SPI_HWCS
-#define SPI_HWCS(x)     (INT_MIN + x)
+#define SPI_HWCS(x)     (UINT_MAX - 1 - x)
 #endif
 
 /**
@@ -97,10 +99,10 @@ typedef gpio_t spi_cs_t;
  */
 #ifndef HAVE_SPI_MODE_T
 typedef enum {
-    SPI_MODE_0,                 /**< CPOL=0, CPHA=0 */
-    SPI_MODE_1,                 /**< CPOL=0, CPHA=1 */
-    SPI_MODE_2,                 /**< CPOL=1, CPHA=0 */
-    SPI_MODE_3                  /**< CPOL=1, CPHA=1 */
+    SPI_MODE_0,             /**< CPOL=0, CPHA=0 */
+    SPI_MODE_1,             /**< CPOL=0, CPHA=1 */
+    SPI_MODE_2,             /**< CPOL=1, CPHA=0 */
+    SPI_MODE_3              /**< CPOL=1, CPHA=1 */
 } spi_mode_t;
 #endif
 
@@ -113,11 +115,11 @@ typedef enum {
  */
 #ifndef HAVE_SPI_CLK_T
 typedef enum {
-    SPI_CLK_100KHZ = 0,         /**< drive the SPI bus with 100KHz */
-    SPI_CLK_400KHZ,             /**< drive the SPI bus with 400KHz */
-    SPI_CLK_1MHZ,               /**< drive the SPI bus with 1MHz */
-    SPI_CLK_5MHZ,               /**< drive the SPI bus with 5MHz */
-    SPI_CLK_10MHZ               /**< drive the SPI bus with 10MHz */
+    SPI_CLK_100KHZ,         /**< drive the SPI bus with 100KHz */
+    SPI_CLK_400KHZ,         /**< drive the SPI bus with 400KHz */
+    SPI_CLK_1MHZ,           /**< drive the SPI bus with 1MHz */
+    SPI_CLK_5MHZ,           /**< drive the SPI bus with 5MHz */
+    SPI_CLK_10MHZ           /**< drive the SPI bus with 10MHz */
 } spi_clk_t;
 #endif
 
@@ -126,15 +128,28 @@ typedef enum {
  *
  * @param[in] dev       initialize pins for this SPI device
  * @param[in] cs        also initialize this chip select pin
+ *
+ * @return              0 on success
+ * @return              -1 on invalid device
+ * @return              -2 on invalid CS
  */
-int spi_init_pins(spi_t dev, spi_cs_t cs);
+int spi_init(spi_t dev, spi_cs_t cs);
 
 /**
- * @brief Get mutually exclusive access to the given SPI bus
+ * @brief   Start a new SPI transaction
  *
- * In case the SPI device is busy, this function will block until the bus is free again.
+ * Starting a new SPI transaction will get exclusive access to the SPI bus
+ * and configure it according to the given values. If another SPI transaction
+ * is active when this function is called, this function will block until the
+ * other transaction is complete (spi_relase was called).
  *
  * @param[in] dev       SPI device to access
+ * @param[in] mode      mode to use for the new transaction
+ * @param[in] clk       bus clock speed to use for the transaction
+ * @param[in] cs        chip select pin to use
+ *
+ * @return              0 on success
+ * @return              -1 on error
  */
 int spi_acquire(spi_t dev, spi_mode_t mode, spi_clk_t clk, spi_cs_t cs);
 
@@ -150,10 +165,10 @@ void spi_release(spi_t dev);
  *
  * @param[in] dev       SPI device to use
  * @param[in] out       Byte to send out, set NULL if only receiving
- * @param[out] in       Byte to read, set NULL if only sending
+ *
+ * @return              The byte that was received
  */
-void spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont,
-                       uint8_t out, uint8_t *in);
+uint8_t spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont, uint8_t out);
 
 /**
  * @brief Transfer a number bytes on the given SPI bus
@@ -178,11 +193,9 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
  * @param[in] out       Byte to send, set NULL if only receiving data
  * @param[out] in       Byte to read, set NULL if only sending
  *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
+ * @return              The value that was read from the given register address
  */
-void spi_transfer_reg(spi_t bus, spi_cs_t cs,
-                      uint8_t reg, uint8_t out, uint8_t *in);
+uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
 
 /**
  * @brief Transfer a number of bytes from/to a given register address
@@ -196,9 +209,6 @@ void spi_transfer_reg(spi_t bus, spi_cs_t cs,
  * @param[in] out       Byte array to send data from, set NULL if only receiving
  * @param[out] in       Byte buffer to read into, set NULL if only sending
  * @param[in] length    Number of bytes to transfer
- *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
  */
 void spi_transfer_regs(spi_t bus, spi_cs_t cs,
                        uint8_t reg, uint8_t *out, uint8_t *in, size_t len);

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -1,19 +1,15 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
  */
 
 /**
  * @defgroup    drivers_periph_spi SPI
  * @ingroup     drivers_periph
  * @brief       Low-level SPI peripheral driver
- *
- * The current design of this interface targets implementations that use the SPI in blocking mode.
- *
- * TODO: add means for asynchronous SPI usage
  *
  * @{
  * @file
@@ -22,137 +18,117 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef SPI_H
-#define SPI_H
+#ifndef PERIPH_SPI_H
+#define PERIPH_SPI_H
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <limits.h>
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
+/* TODO: remove once all platforms are ported to this interface */
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* add guard for the case that no SPI device is defined */
-#if SPI_NUMOF
+/**
+ * @brief   Default SPI device access macro
+ */
+#ifndef SPI_DEV
+#define SPI_DEV(x)      (x)
+#endif
 
 /**
- * @brief Definition available SPI devices
+ * @brief   Define global value for undefined SPI device
  */
+#ifndef SPI_UNDEF
+#define SPI_UNDEF       (-1)
+#endif
+
+/**
+ * @brief   Default SPI chip select pin access macro
+ */
+#ifndef SPI_HWCS
+#define SPI_HWCS(x)     (INT_MIN + x)
+#endif
+
+/**
+ * @brief   Define value for unused CS line
+ */
+#ifndef SPI_CS_UNDEF
+#define SPI_CS_UNDEF    (GPIO_UNDEF)
+#endif
+
+/**
+ * @brief   Default type for SPI devices
+ */
+#ifndef HAVE_SPI_T
+typedef unsigned int spi_t;
+#endif
+
+/**
+ * @brief   Chip select pin type overlaps with gpio_t so it can be casted to
+ *          this
+ */
+#ifndef HAVE_SPI_CS_T
+typedef gpio_t spi_cs_t;
+#endif
+
+/**
+ * @brief   Available SPI modes, defining the configuration of clock polarity
+ *          and clock phase
+ *
+ * RIOT is using the mode numbers as commonly defined by most vendors
+ * (https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Mode_numbers):
+ *
+ * - MODE_0: CPOL=0, CPHA=0 - The first data bit is sampled by the receiver on
+ *           the first SCK rising SCK edge (this mode is used most often).
+ * - MODE_1: CPOL=0, CPHA=1 - The first data bit is sampled by the receiver on
+ *           the second rising SCK edge.
+ * - MODE_2: CPOL=1, CPHA=0 - The first data bit is sampled by the receiver on
+ *           the first falling SCK edge.
+ * - MODE_3: CPOL=1, CPHA=1 - The first data bit is sampled by the receiver on
+ *           the second falling SCK edge.
+ */
+#ifndef HAVE_SPI_MODE_T
 typedef enum {
-#if SPI_0_EN
-    SPI_0 = 0,          /**< SPI device 0 */
+    SPI_MODE_0,                 /**< CPOL=0, CPHA=0 */
+    SPI_MODE_1,                 /**< CPOL=0, CPHA=1 */
+    SPI_MODE_2,                 /**< CPOL=1, CPHA=0 */
+    SPI_MODE_3                  /**< CPOL=1, CPHA=1 */
+} spi_mode_t;
 #endif
-#if SPI_1_EN
-    SPI_1,              /**< SPI device 1 */
-#endif
-#if SPI_2_EN
-    SPI_2,              /**< SPI device 2 */
-#endif
-#if SPI_3_EN
-    SPI_3,              /**< SPI device 3 */
-#endif
-} spi_t;
 
 /**
- * @brief The SPI mode is defined by the four possible combinations of clock polarity and
- *        clock phase.
- * @{
+ * @brief   Available SPI clock speeds
+ *
+ * The actual speed of the bus can vary to some extend, as the combination of
+ * CPU clock and available prescaler values on certain platforms may not make
+ * the exact values possible.
  */
-#ifndef HAVE_SPI_CONF_T
+#ifndef HAVE_SPI_CLK_T
 typedef enum {
-    /**
-     * The first data bit is sampled by the receiver on the first SCK edge. The
-     * first edge of SCK is rising. This is sometimes also referred to as SPI
-     * mode 0, or (CPOL=0, CPHA=0).
-     */
-    SPI_CONF_FIRST_RISING = 0,
-    /**
-     * The first data bit is sampled by the receiver on the second SCK edge. The
-     * first edge of SCK is rising, i.e. the sampling edge is falling. This is
-     * sometimes also referred to as SPI mode 1, or (CPOL=0, CPHA=1).
-     */
-    SPI_CONF_SECOND_RISING = 1,
-    /**
-     * The first data bit is sampled by the receiver on the first SCK edge. The
-     * first edge of SCK is falling. This is sometimes also referred to as SPI
-     * mode 2, or (CPOL=1, CPHA=0).
-     */
-    SPI_CONF_FIRST_FALLING = 2,
-    /**
-     * The first data bit is sampled by the receiver on the second SCK edge. The
-     * first edge of SCK is falling, i.e. the sampling edge is rising. This is
-     * sometimes also referred to as SPI mode 3, or (CPOL=1, CPHA=1).
-     */
-    SPI_CONF_SECOND_FALLING = 3
-} spi_conf_t;
+    SPI_CLK_100KHZ = 0,         /**< drive the SPI bus with 100KHz */
+    SPI_CLK_400KHZ,             /**< drive the SPI bus with 400KHz */
+    SPI_CLK_1MHZ,               /**< drive the SPI bus with 1MHz */
+    SPI_CLK_5MHZ,               /**< drive the SPI bus with 5MHz */
+    SPI_CLK_10MHZ               /**< drive the SPI bus with 10MHz */
+} spi_clk_t;
 #endif
-/** @} */
 
 /**
- * @brief Define a set of pre-defined SPI clock speeds.
+ * @brief   Initialize pins used by the given SPI device
  *
- * The actual speed of the bus can vary to some extend, as the combination of CPU clock and
- * available prescale values on certain platforms may not make the exact values possible.
- *
- * @{
+ * @param[in] dev       initialize pins for this SPI device
+ * @param[in] cs        also initialize this chip select pin
  */
-#ifndef HAVE_SPI_SPEED_T
-typedef enum {
-    SPI_SPEED_100KHZ = 0,       /**< drive the SPI bus with 100KHz */
-    SPI_SPEED_400KHZ,           /**< drive the SPI bus with 400KHz */
-    SPI_SPEED_1MHZ,             /**< drive the SPI bus with 1MHz */
-    SPI_SPEED_5MHZ,             /**< drive the SPI bus with 5MHz */
-    SPI_SPEED_10MHZ             /**< drive the SPI bus with 10MHz */
-} spi_speed_t;
-#endif
-/** @} */
+int spi_init_pins(spi_t dev, spi_cs_t cs);
 
-/**
- * @brief Initialize the given SPI device to work in master mode
- *
- * In master mode the SPI device is configured to control the SPI bus. This means the device
- * will start and end all communication on the bus and control the CLK line. For transferring
- * data on the bus the below defined transfer functions should be used.
- *
- * @param[in] dev       SPI device to initialize
- * @param[in] conf      Mode of clock phase and clock polarity
- * @param[in] speed     desired clock speed for driving the SPI bus
- *
- * @return              0 on success
- * @return              -1 on unavailable speed value
- * @return              -2 on other errors
- */
-int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed);
-
-/**
- * @brief Initialize the given SPI device to work in slave mode
- *
- * In slave mode the SPI device is purely reacting to the bus. Transaction will be started and
- * ended by a connected SPI master. When a byte is received, the callback is called in interrupt
- * context with this byte as argument. The return byte of the callback is transferred to the
- * master in the next transmission cycle. This interface enables easy implementation of a register
- * based access paradigm for the SPI slave.
- *
- * @param[in] dev       The SPI device to initialize as SPI slave
- * @param[in] conf      Mode of clock phase and polarity
- * @param[in] cb        callback called every time a byte was received
- *
- * @return              0 on success
- * @return              -1 on error
- */
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data));
-
-/**
- * @brief Configure SCK, MISO and MOSI pins for the given SPI device
- *
- * @param[in] dev       SPI device to use
- *
- * @return              0 on success
- * @return              -1 on error
- */
-int spi_conf_pins(spi_t dev);
 
 /**
  * @brief Get mutually exclusive access to the given SPI bus
@@ -160,21 +136,15 @@ int spi_conf_pins(spi_t dev);
  * In case the SPI device is busy, this function will block until the bus is free again.
  *
  * @param[in] dev       SPI device to access
- *
- * @return              0 on success
- * @return              -1 on error
  */
-int spi_acquire(spi_t dev);
+int spi_acquire(spi_t dev, spi_mode_t mode, spi_clk_t clk, spi_cs_t cs);
 
 /**
  * @brief Release the given SPI device to be used by others
  *
  * @param[in] dev       SPI device to release
- *
- * @return              0 on success
- * @return              -1 on error
  */
-int spi_release(spi_t dev);
+void spi_release(spi_t dev);
 
 /**
  * @brief Transfer one byte on the given SPI bus
@@ -182,11 +152,9 @@ int spi_release(spi_t dev);
  * @param[in] dev       SPI device to use
  * @param[in] out       Byte to send out, set NULL if only receiving
  * @param[out] in       Byte to read, set NULL if only sending
- *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
  */
-int spi_transfer_byte(spi_t dev, char out, char *in);
+void spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont,
+                       uint8_t out, uint8_t *in);
 
 /**
  * @brief Transfer a number bytes on the given SPI bus
@@ -195,11 +163,9 @@ int spi_transfer_byte(spi_t dev, char out, char *in);
  * @param[in] out       Array of bytes to send, set NULL if only receiving
  * @param[out] in       Buffer to receive bytes to, set NULL if only sending
  * @param[in] length    Number of bytes to transfer
- *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
  */
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length);
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        uint8_t *out, uint8_t *in, size_t len);
 
 /**
  * @brief Transfer one byte to/from a given register address
@@ -216,7 +182,8 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length);
  * @return              Number of bytes that were transfered
  * @return              -1 on error
  */
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in);
+void spi_transfer_reg(spi_t bus, spi_cs_t cs,
+                      uint8_t reg, uint8_t out, uint8_t *in);
 
 /**
  * @brief Transfer a number of bytes from/to a given register address
@@ -234,35 +201,12 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in);
  * @return              Number of bytes that were transfered
  * @return              -1 on error
  */
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length);
-
-/**
- * @brief Tell the SPI driver that a new transaction was started. Call only when SPI in slave mode!
- *
- * @param[in] dev       SPI device that is active
- * @param[in] reset_val The byte that is send to the master as first byte
- */
-void spi_transmission_begin(spi_t dev, char reset_val);
-
-/**
- * @brief Power on the given SPI device
- *
- * @param[in] dev       SPI device to power on
- */
-void spi_poweron(spi_t dev);
-
-/**
- * @brief Power off the given SPI device
- *
- * @param[in] dev       SPI device to power off
- */
-void spi_poweroff(spi_t dev);
-
-#endif /* SPI_NUMOF */
+void spi_transfer_regs(spi_t bus, spi_cs_t cs,
+                       uint8_t reg, uint8_t *out, uint8_t *in, size_t len);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* SPI_H */
+#endif /* PERIPH_SPI_H */
 /** @} */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -211,14 +211,15 @@ int spi_init_cs(spi_t bus, spi_cs_t cs);
  * is active when this function is called, this function will block until the
  * other transaction is complete (spi_relase was called).
  *
+ * @note    This function expects the @p bus and the @p cs parameters to be
+ *          valid (they are checked in spi_init and spi_init_cs before)
+ *
  * @param[in] bus       SPI device to access
  * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
  * @param[in] mode      mode to use for the new transaction
  * @param[in] clk       bus clock speed to use for the transaction
  *
  * @return              SPI_OK on success
- * @return              SPI_NODEV on invalid device
- * @return              SPI_NOCS on invalid CS pin/line
  * @return              SPI_NOMODE if given mode is not supported
  * @return              SPI_NOCLK if given clock speed is not supported
  */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -179,7 +179,7 @@ uint8_t spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont, uint8_t out);
  * @param[in] length    Number of bytes to transfer
  */
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
-                        uint8_t *out, uint8_t *in, size_t len);
+                        const void *out, void *in, size_t len);
 
 /**
  * @brief Transfer one byte to/from a given register address
@@ -211,7 +211,7 @@ uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
  * @param[in] length    Number of bytes to transfer
  */
 void spi_transfer_regs(spi_t bus, spi_cs_t cs,
-                       uint8_t reg, uint8_t *out, uint8_t *in, size_t len);
+                       uint8_t reg, const void *out, void *in, size_t len);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -107,12 +107,15 @@ typedef unsigned int spi_t;
 typedef gpio_t spi_cs_t;
 #endif
 
-typedef enum {
-    SPI_OK          = -1,
-    SPI_NODEV       = -2,
-    SPI_NOCS        = -3,
-    SPI_NOMODE      = -4,
-    SPI_NOCLK       = -5
+/**
+ * @brief   Status codes used by the SPI driver interface
+ */
+enum {
+    SPI_OK          =  0,   /**< everything went as planned */
+    SPI_NODEV       = -1,   /**< invalid SPI bus specified */
+    SPI_NOCS        = -2,   /**< invalid chip select line specified */
+    SPI_NOMODE      = -3,   /**< selected mode is not supported */
+    SPI_NOCLK       = -4    /**< selected clock value is not supported */
 };
 
 /**
@@ -262,7 +265,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
  * @param[in] out       Byte to send, set NULL if only receiving data
  * @param[out] in       Byte to read, set NULL if only sending
  *
- * @return              The value that was read from the given register address
+ * @return              value that was read from the given register address
  */
 uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
 

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -212,7 +212,7 @@ int spi_init_cs(spi_t bus, spi_cs_t cs);
  * other transaction is complete (spi_relase was called).
  *
  * @param[in] bus       SPI device to access
- * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
  * @param[in] mode      mode to use for the new transaction
  * @param[in] clk       bus clock speed to use for the transaction
  *
@@ -238,7 +238,7 @@ void spi_release(spi_t bus);
  * @brief Transfer one byte on the given SPI bus
  *
  * @param[in] bus       SPI device to use
- * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
  * @param[in] cont      if true, keep device selected after transfer
  * @param[in] out       byte to send out, set NULL if only receiving
  *
@@ -265,11 +265,10 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
  * This function is a shortcut function for easier handling of SPI devices that
  * implement a register based access scheme.
  *
- * @param[in]  bus      SPI device to use
- * @param[in]  cs       chip select pin/line to use, may be GPIO_UNDEF
- * @param[in] reg       Register address to transfer data to/from
- * @param[in] out       Byte to send, set NULL if only receiving data
- * @param[out] in       Byte to read, set NULL if only sending
+ * @param[in] bus       SPI device to use
+ * @param[in] cs        chip select pin/line to use, may be GPIO_UNDEF
+ * @param[in] reg       register address to transfer data to/from
+ * @param[in] out       byte to send, set NULL if only receiving data
  *
  * @return              value that was read from the given register address
  */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -178,12 +178,12 @@ typedef enum {
  * It uses the board specific initialization parameters as defined in the
  * board's `periph_conf.h`.
  *
- * @param[in] bus       SPI device to initialize
+ * Errors (e.g. invalid @p bus parameter) are not signaled through a return
+ * value, but should be signaled using the assert() function internally.
  *
- * @return              SPI_OK on success
- * @return              SPI_NODEV on invalid device
+ * @param[in] bus       SPI device to initialize
  */
-int spi_init(spi_t bus);
+void spi_init(spi_t bus);
 
 /**
  * @brief   Initialize the given chip select pin

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -14,6 +15,7 @@
  * @brief       common SPI function fallback implementations
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -24,68 +26,28 @@
 #include "periph/spi.h"
 #include "periph_cpu.h"
 
-#if SPI_NUMOF
-
-#ifdef PERIPH_SPI_NEEDS_TRANSFER_BYTES
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+#ifdef PERIPH_SPI_NEEDS_TRANSFER_BYTE
+uint8_t spi_transfer_byte(spi_t bus, spi_cs_t cs, bool cont, uint8_t out)
 {
-    int trans_ret;
-    unsigned trans_bytes = 0;
-    char in_temp;
-
-    for (trans_bytes = 0; trans_bytes < length; trans_bytes++) {
-        if (out != NULL) {
-            trans_ret = spi_transfer_byte(dev, out[trans_bytes], &in_temp);
-        }
-        else {
-            trans_ret = spi_transfer_byte(dev, 0, &in_temp);
-        }
-        if (trans_ret < 0) {
-            return -1;
-        }
-        if (in != NULL) {
-            in[trans_bytes] = in_temp;
-        }
-    }
-
-    return trans_bytes;
+    uint8_t in;
+    spi_transfer_bytes(bus, cs, cont, &out, &in, 1);
+    return in;
 }
 #endif
 
 #ifdef PERIPH_SPI_NEEDS_TRANSFER_REG
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out)
 {
-    int trans_ret;
-
-    trans_ret = spi_transfer_byte(dev, reg, in);
-    if (trans_ret < 0) {
-        return -1;
-    }
-    trans_ret = spi_transfer_byte(dev, out, in);
-    if (trans_ret < 0) {
-        return -1;
-    }
-
-    return 1;
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    return spi_transfer_byte(bus, cs, false, out);
 }
 #endif
 
 #ifdef PERIPH_SPI_NEEDS_TRANSFER_REGS
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+void spi_transfer_regs(spi_t bus, spi_cs_t cs,
+                       uint8_t reg, const void *out, void *in, size_t len)
 {
-    int trans_ret;
-
-    trans_ret = spi_transfer_byte(dev, reg, in);
-    if (trans_ret < 0) {
-        return -1;
-    }
-    trans_ret = spi_transfer_bytes(dev, out, in, length);
-    if (trans_ret < 0) {
-        return -1;
-    }
-
-    return trans_ret;
+    spi_transfer_bytes(bus, cs, true, &reg, NULL, 1);
+    spi_transfer_bytes(bus, cs, false, out, in, len);
 }
 #endif
-
-#endif /* SPI_NUMOF */

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -210,12 +210,6 @@ int main(void)
     /* reset local SPI configuration */
     spiconf.dev = SPI_UNDEF;
 
-    /* do base initialization of configured SPI devices
-       TODO: remove once spi_init calls are moved into board_init/kernel_init */
-    for (int i = 0; i < (int)SPI_NUMOF; i++) {
-        spi_init(SPI_DEV(i));
-    }
-
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -40,15 +40,15 @@ static struct {
 
 void print_bytes(char* title, uint8_t* data, size_t len)
 {
-    printf("%4s", title);
+    printf("%4s\n", title);
     for (size_t i = 0; i < len; i++) {
         printf("  %2i ", (int)i);
     }
-    printf("\n    ");
+    printf("\n ");
     for (size_t i = 0; i < len; i++) {
         printf(" 0x%02x", (int)data[i]);
     }
-    printf("\n    ");
+    printf("\n ");
     for (size_t i = 0; i < len; i++) {
         if (data[i] < ' ' || data[i] > '~') {
             printf("  ?? ");
@@ -83,7 +83,7 @@ int cmd_config(int argc, char **argv)
         puts("\t\t4: 10 MHz");
         puts("\tcs port:");
         puts("\t\tPort of the CS pin, set to -1 for hardware chip select");
-        puts("\t\tcs pin:");
+        puts("\tcs pin:");
         puts("\t\tPin used for chip select. If hardware chip select is enabled,\n"
              "\t\tthis value specifies the internal HWCS line");
         return 1;
@@ -181,13 +181,13 @@ int cmd_transfer(int argc, char **argv)
 
     /* transfer data */
     len = strlen(argv[1]);
-    spi_transfer_bytes(spiconf.dev, spiconf.cs, false, argv[2], buf, len);
+    spi_transfer_bytes(spiconf.dev, spiconf.cs, false, argv[1], buf, len);
 
     /* release the bus */
     spi_release(spiconf.dev);
 
     /* print results */
-    print_bytes("Sent bytes", (uint8_t *)argv[2], len);
+    print_bytes("Sent bytes", (uint8_t *)argv[1], len);
     print_bytes("Received bytes", buf, len);
 
     return 0;

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -24,307 +24,200 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "board.h"
 #include "shell.h"
 #include "periph/spi.h"
-#include "periph/gpio.h"
 
-enum {
-    READ = 0,
-    WRITE,
-    INIT
-} rw;
+#define LINE_LIMIT              (10U)
 
-static int spi_dev = -1;
-static gpio_t spi_cs = -1;
-static int spi_mode_int = -1;
-static spi_conf_t spi_mode = -1;
-static int spi_speed_int = -1;
-static spi_speed_t spi_speed = -1;
+#define BUF_SIZE                (256U)
 
-/* 0 for slave, 1 for master, -1 for not initialized */
-static int spi_master = -1;
-static int port = -1;
-static int pin = -1;
+typedef struct {
+    spi_t dev;
+    spi_mode_t mode;
+    spi_clk_t clk;
+    spi_cs_t cs;
+} spi_line_t;
 
-static char buffer[256];       /* temporary buffer */
-static char rx_buffer[256];    /* global receive buffer */
-static int rx_counter = 0;
+static spi_line_t config[LINE_LIMIT];
 
-static volatile int state;
-static char* mem = "Hello Master! abcdefghijklmnopqrstuvwxyz 0123456789 "
-                   "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static uint8_t buf[BUF_SIZE];
 
-int parse_spi_dev(int argc, char **argv)
+
+static void print_config_help(const char *cmd)
 {
-    /* reset default values */
-    spi_dev = SPI_0;
-    spi_mode = SPI_CONF_FIRST_RISING;
-    spi_speed = SPI_SPEED_1MHZ;
-
-    if (argc < 4) {
-        printf("usage: %s <dev> <cs port> <cs pin> [mode [speed]]\n", argv[0]);
-        puts("        DEV is the SPI device to use:");
-        for (int i = 0; i < SPI_NUMOF; i++) {
-            printf("             %i - SPI_%i\n", i, i);
-        }
-        puts("        cs port:  port to use as the chip select line");
-        puts("        cs pin:   pin to use on th given port as cs line");
-        puts("        mode: must be one of the following options (* marks "
-                      "default value):");
-        puts("            *0 - POL:0, PHASE:0 - ON FIRST RISING EDGE");
-        puts("             1 - POL:0, PHASE:1 - ON SECOND RISING EDGE");
-        puts("             2 - POL:1, PHASE:0 - ON FIRST FALLING EDGE");
-        puts("             3 - POL:1, PHASE:1 - on second falling edge");
-        puts("        speed: must be one of the following options (only used "
-                      "in master mode):");
-        puts("             0 - 100 KHz");
-        puts("             1 - 400 KHz");
-        puts("            *2 - 1 MHz");
-        puts("             3 - 5 MHz");
-        puts("             4 - 10 MHz\n");
-        return -4;
+    printf("usage: %s <config> <dev> <mode> <clk> <cs port> <cs pin>\n", cmd);
+    puts("\tdev:");
+    for (int i = 0; i < (int)SPI_NUMOF; i++) {
+        printf("\t\t%i: SPI_DEV(%i)\n", i, i);
     }
-    spi_dev = atoi(argv[1]);
-    if (spi_dev < 0 || spi_dev >= SPI_NUMOF) {
-        puts("error: invalid DEV value given");
-        return -1;
-    }
-    port = atoi(argv[2]);
-    pin = atoi(argv[3]);
-    spi_cs = GPIO_PIN(port,pin);
-    if (argc >= 5) {
-        spi_mode_int = argv[4][0] - '0';
-        if (spi_mode_int < 0 || spi_mode_int > 3) {
-            puts("error: invalid MODE value given");
-            return -2;
-        } else {
-            switch (spi_mode_int) {
-                case 0:
-                    spi_mode = SPI_CONF_FIRST_RISING;
-                    break;
-                case 1:
-                    spi_mode = SPI_CONF_SECOND_RISING;
-                    break;
-                case 2:
-                    spi_mode = SPI_CONF_FIRST_FALLING;
-                    break;
-                case 3:
-                    spi_mode = SPI_CONF_SECOND_FALLING;
-                    break;
-            }
-        }
-    }
-    if (argc >= 6) {
-        spi_speed_int = argv[5][0] - '0';
-        if (spi_speed_int < 0 || spi_speed_int > 4) {
-            puts("error: invalid SPEED value given");
-            return -3;
-        } else {
-            switch (spi_speed_int) {
-                case 0:
-                    spi_speed = SPI_SPEED_100KHZ;
-                    break;
-                case 1:
-                    spi_speed = SPI_SPEED_400KHZ;
-                    break;
-                case 2:
-                    spi_speed = SPI_SPEED_1MHZ;
-                    break;
-                case 3:
-                    spi_speed = SPI_SPEED_5MHZ;
-                    break;
-                case 4:
-                    spi_speed = SPI_SPEED_10MHZ;
-                    break;
-            }
-        }
-    }
-    return 0;
+    puts("\tconfig:");
+    puts("\t\tConfiguration channel to save this to");
+    puts("\tmode:");
+    puts("\t\t0: POL:0, PHASE:0 - on first rising edge");
+    puts("\t\t1: POL:0, PHASE:1 - on second rising edge");
+    puts("\t\t2: POL:1, PHASE:0 - on first falling edge");
+    puts("\t\t3: POL:1, PHASE:1 - on second falling edge");
+    puts("\tclk:");
+    puts("\t\t0: 100 KHz");
+    puts("\t\t1: 400 KHz");
+    puts("\t\t2: 1 MHz");
+    puts("\t\t3: 5 MHz");
+    puts("\t\t4: 10 MHz");
+    puts("\tcs port:");
+    puts("\t\tPort of the CS pin, set to -1 for hardware chip select");
+    puts("\t\tcs pin:");
+    puts("\t\tPin used for chip select. If hardware chip select is enabled,\n"
+         "\t\tthis value specifies the internal HWCS line");
 }
 
-void print_bytes(char* title, char* chars, int length)
+void print_bytes(char* title, uint8_t* data, size_t len)
 {
     printf("%4s", title);
-    for (int i = 0; i < length; i++) {
-        printf("  %2i ", i);
+    for (size_t i = 0; i < len; i++) {
+        printf("  %2i ", (int)i);
     }
     printf("\n    ");
-    for (int i = 0; i < length; i++) {
-        printf(" 0x%02x", (int)chars[i]);
+    for (size_t i = 0; i < len; i++) {
+        printf(" 0x%02x", (int)data[i]);
     }
     printf("\n    ");
-    for (int i = 0; i < length; i++) {
-        if (chars[i] < ' ' || chars[i] > '~') {
+    for (size_t i = 0; i < len; i++) {
+        if (data[i] < ' ' || data[i] > '~') {
             printf("  ?? ");
         }
         else {
-            printf("   %c ", chars[i]);
+            printf("   %c ", (char)data[i]);
         }
     }
     printf("\n\n");
 }
 
-void slave_on_cs(void *arg)
+int cmd_config(int argc, char **argv)
 {
-    (void)arg;
+    int line, tmp, ump;
 
-    spi_transmission_begin(spi_dev, 'F');
-    state = 0;
-    rw = INIT;
-}
-
-char slave_on_data(char data)
-{
-    rx_buffer[rx_counter] = data;
-    rx_counter++;
-    if (rx_counter >= 256) {
-        rx_counter = 0;
+    if (argc < 7) {
+        print_config_help(argv[0]);
+        return 1;
     }
 
-    switch (rw) {
-        case READ:
-            return mem[state++];
-        case WRITE:
-            mem[state++] = data;
-            return 'o';
-        case INIT:
-            if (data == ' ') {
-                rw = READ;
-                return mem[state++];
-            } else if (data & 0x80) {
-                rw = WRITE;
-                state = (data & 0x7f);
-                return 'W';
-            } else {
-                rw = READ;
-                state = data;
-                return mem[state++];
-            }
+    line = atoi(argv[1]);
+    if (line < 0 || line >= LINE_LIMIT) {
+        puts("error: invalid configuration channel");
+        return 1;
     }
-    return 'e';
-}
 
-int cmd_init_master(int argc, char **argv)
-{
-    int res;
-    spi_master = -1;
-    if (parse_spi_dev(argc, argv) < 0) {
-        return 1;
+    tmp = atoi(argv[3]);                /* parse SPI mode */
+    switch (tmp) {
+        case 0: config[line].mode = SPI_MODE_0; break;
+        case 1: config[line].mode = SPI_MODE_1; break;
+        case 2: config[line].mode = SPI_MODE_2; break;
+        case 3: config[line].mode = SPI_MODE_3; break;
+        default:
+            puts("error: invalid SPI mode specified");
+            return 1;
     }
-    spi_acquire(spi_dev);
-    res = spi_init_master(spi_dev, spi_mode, spi_speed);
-    spi_release(spi_dev);
-    if (res < 0) {
-        printf("spi_init_master: error initializing SPI_%i device (code %i)\n",
-                spi_dev, res);
-        return 1;
-    }
-    res = gpio_init(spi_cs, GPIO_OUT);
-    if (res < 0){
-        printf("gpio_init: error initializing GPIO_PIN(%i, %i) as CS line (code %i)\n",
-                port, pin, res);
-        return 1;
-    }
-    gpio_set(spi_cs);
-    spi_master = 1;
-    printf("SPI_%i successfully initialized as master, cs: GPIO_PIN(%i, %i), mode: %i, speed: %i\n",
-            spi_dev, port, pin, spi_mode_int, spi_speed_int);
-    return 0;
-}
 
-int cmd_init_slave(int argc, char **argv)
-{
-    int res;
-    spi_master = -1;
-    if (parse_spi_dev(argc, argv) < 0) {
+    tmp = atoi(argv[4]);                /* parse bus clock speed */
+    switch (tmp) {
+        case 0: config[line].clk = SPI_CLK_100KHZ; break;
+        case 1: config[line].clk = SPI_CLK_400KHZ; break;
+        case 2: config[line].clk = SPI_CLK_1MHZ;   break;
+        case 3: config[line].clk = SPI_CLK_5MHZ;   break;
+        case 4: config[line].clk = SPI_CLK_10MHZ;  break;
+        default:
+            puts("error: invalid bus speed specified");
+            return 1;
+    }
+
+    tmp = atoi(argv[5]);
+    ump = atoi(argv[6]);
+    if (ump < 0 || tmp < -1) {
+        puts("error: invalid port/pin combination specified");
+    }
+    if (tmp == -1) {                    /* hardware chip select line */
+        config[line].cs = SPI_HWCS(ump);
+    }
+    else {
+        config[line].cs = (spi_cs_t)GPIO_PIN(tmp, ump);
+    }
+
+    tmp = atoi(argv[2]);                /* parse SPI dev */
+    if (tmp < 0 || tmp >= SPI_NUMOF) {
+        puts("error: invalid SPI device specified");
         return 1;
     }
-    spi_acquire(spi_dev);
-    res = spi_init_slave(spi_dev, spi_mode, slave_on_data);
-    spi_release(spi_dev);
-    if (res < 0) {
-        printf("spi_init_slave: error initializing SPI_%i device (code: %i)\n",
-                spi_dev, res);
+    config[line].dev = SPI_DEV(tmp);
+
+    if (spi_init_pins(config[line].dev, config[line].cs) < 0) {
+        puts("error: unable to initialize the given SPI device");
+        config[line].dev = SPI_UNDEF;
         return 1;
     }
-    res = gpio_init_int(spi_cs, GPIO_IN, GPIO_FALLING, slave_on_cs, 0);
-    if (res < 0){
-        printf("gpio_init_int: error initializing GPIO_PIN(%i, %i) as CS line (code %i)\n",
-                port, pin, res);
-        return 1;
-    }
-    spi_master = 0;
-    printf("SPI_%i successfully initialized as slave, cs: GPIO_PIN(%i, %i), mode: %i\n",
-            spi_dev, port, pin, spi_mode_int);
+
     return 0;
 }
 
 int cmd_transfer(int argc, char **argv)
 {
-    int res;
-    char *hello = "Hello";
-
-    if (spi_master != 1) {
-        puts("error: node is not initialized as master, please do so first");
-        return 1;
-    }
+    int line;
+    size_t len;
 
     if (argc < 2) {
-        puts("No data to transfer given, will transfer 'Hello' to device");
-    }
-    else {
-        hello = argv[1];
+        printf("usage: %s <config> <data>\n", argv[0]);
     }
 
-    /* do the actual data transfer */
-    spi_acquire(spi_dev);
-    gpio_clear(spi_cs);
-    res = spi_transfer_bytes(spi_dev, hello, buffer, strlen(hello));
-    gpio_set(spi_cs);
-    spi_release(spi_dev);
-
-    /* look at the results */
-    if (res < 0) {
-        printf("error: unable to transfer data to slave (code: %i)\n", res);
+    line = atoi(argv[1]);
+    if (line < 0 || line >= LINE_LIMIT) {
+        puts("error: invalid configuration channel specified");
         return 1;
     }
-    else {
-        printf("Transfered %i bytes:\n", res);
-        print_bytes("MOSI", hello, res);
-        print_bytes("MISO", buffer, res);
-        return 0;
-    }
-}
-
-int cmd_print(int argc, char **argv)
-{
-    if (spi_master != 0) {
-        puts("error: node is not initialized as slave");
+    if (config[line].dev == SPI_UNDEF) {
+        puts("error: the given configuration channel is not initialized");
         return 1;
     }
-    else {
-        printf("Received %i bytes:\n", rx_counter);
-        print_bytes("MOSI", rx_buffer, rx_counter);
+
+    /* get bus access */
+    if (spi_acquire(config[line].dev, config[line].mode,
+                    config[line].clk, config[line].cs) < 0) {
+        puts("error: unable to acquire the bus with the given configuration");
     }
-    rx_counter = 0;
-    memset(&rx_buffer, 0, 256);
+
+    /* transfer data */
+    len = strlen(argv[2]);
+    spi_transfer_bytes(config[line].dev, config[line].cs, false,
+                       (uint8_t *)argv[2], buf, len);
+
+    /* release the bus */
+    spi_release(config[line].dev);
+
+    /* print results */
+    print_bytes("Send bytes", (uint8_t *)argv[2], len);
+    print_bytes("Received bytes", buf, len);
+
     return 0;
 }
 
+
 static const shell_command_t shell_commands[] = {
-    { "init_master", "Initialize node as SPI master", cmd_init_master },
-    { "init_slave", "Initialize node as SPI slave", cmd_init_slave },
+    { "config", "Setup a particular SPI configuration", cmd_config },
     { "send", "Transfer string to slave (only in master mode)", cmd_transfer },
-    { "print_rx", "Print the received string (only in slave mode)", cmd_print },
     { NULL, NULL, NULL }
 };
 
 int main(void)
 {
+    /* un-initialize the configuration lines */
+    for (size_t line = 0; line < LINE_LIMIT; line++) {
+        config[line].dev = SPI_UNDEF;
+    }
+
     puts("\nRIOT low-level SPI driver test");
-    puts("This application enables you to test a platforms SPI driver implementation.");
-    puts("Enter 'help' to get started\n");
+    puts("This application enables you to test a platforms SPI driver \n"
+         "implementation. Type 'help' to show the available commands.\n");
+
+    printf("There are %i SPI devices configured for your platform:\n",
+           (int)SPI_NUMOF);
 
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -192,7 +192,7 @@ int cmd_transfer(int argc, char **argv)
     spi_release(config[line].dev);
 
     /* print results */
-    print_bytes("Send bytes", (uint8_t *)argv[2], len);
+    print_bytes("Sent bytes", (uint8_t *)argv[2], len);
     print_bytes("Received bytes", buf, len);
 
     return 0;


### PR DESCRIPTION
These are the changes for the SODAQ Autonomo board.

SPI is connected to a 16Mbit data flash. I'm using (modified) tests/periph_spi as a quick test to the device ID. I get:

```
Received bytes
   0    1    2    3    4    5 
  0xff 0x1f 0x26 0x00 0x01 0x00
   ??   ??    &   ??   ??   ?? 
```

which tells me that it is correct.
