### PR TITLE
boards/sodaq-autonomo: use comma on last element of a list too

### DIFF
--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -108,7 +108,7 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA,10),
         .mux    = GPIO_MUX_C,
         .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_2
+        .tx_pad = UART_PAD_TX_2,
     },
     {
         .dev    = &SERCOM5->USART,
@@ -116,7 +116,7 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PB,30),
         .mux    = GPIO_MUX_D,
         .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_0_RTS_2_CTS_3
+        .tx_pad = UART_PAD_TX_0_RTS_2_CTS_3,
     },
     {
         .dev    = &SERCOM4->USART,
@@ -124,7 +124,7 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA,14),
         .mux    = GPIO_MUX_C,
         .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_2
+        .tx_pad = UART_PAD_TX_2,
     },
     {
         .dev    = &SERCOM1->USART,
@@ -132,8 +132,8 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA,18),
         .mux    = GPIO_MUX_C,
         .rx_pad = UART_PAD_RX_1,
-        .tx_pad = UART_PAD_TX_2
-    }
+        .tx_pad = UART_PAD_TX_2,
+    },
 };
 
 /* interrupt function name mapping */

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -283,6 +283,9 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 
     RFCORE_SFR_RFST = ISTXON;
 
+    /* Wait for transmission to complete */
+    RFCORE_WAIT_UNTIL(RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE == 0);
+
     return pkt_len;
 }
 

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -316,9 +316,10 @@ typedef struct sock_ip sock_ip_t;
  *          elsewhere
  * @return  -EAFNOSUPPORT, if `local != NULL` or `remote != NULL` and
  *          sock_ip_ep_t::family of @p local or @p remote is not supported.
- * @return  -EINVAL, if `proto` is not supported or if sock_ip_ep_t::netif of
- *          @p local or @p remote is not a valid interface or contradict each
- *          other (i.e. `(local->netif != remote->netif) &&
+ * @return  -EINVAL, if sock_ip_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_ip_ep_t::netif of @p local or @p remote are not
+ *          valid interfaces or contradict each other
+ *          (i.e. `(local->netif != remote->netif) &&
  *          ((local->netif != SOCK_ADDR_ANY_NETIF) ||
  *          (remote->netif != SOCK_ADDR_ANY_NETIF))` if neither is `NULL`).
  * @return  -ENOMEM, if not enough resources can be provided for `sock` to be
@@ -432,6 +433,9 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
  * @return  The number of bytes sent on success.
  * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_ip_ep_t::family of
  *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EINVAL, if sock_ip_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_ip_ep_t::netif of @p remote is not a
+ *          valid interface or contradicts the local interface of @p sock.
  * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
  *          reachable.
  * @return  -ENOMEM, if no memory was available to send @p data.

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -116,7 +116,7 @@ int sock_tcp_connect(sock_tcp_t *sock, const sock_tcp_ep_t *remote,
  * @return  -ENOMEM, if no memory was available to listen on @p queue.
  */
 int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
-                    sock_tcp_t[] queue_array, unsigned queue_len,
+                    sock_tcp_t *queue_array, unsigned queue_len,
                     uint16_t flags);
 
 /**

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -83,6 +83,7 @@ typedef struct sock_tcp_queue sock_tcp_queue_t;
  * @return  -EAFNOSUPPORT, if sock_tcp_ep_t::family of @p remote is not
  *          supported.
  * @return  -ECONNREFUSED, if no-one is listening on the @p remote end point.
+ * @return  -EINVAL, if sock_tcp_ep_t::addr of @p remote is an invalid address.
  * @return  -EINVAL, if sock_tcp_ep_t::netif of @p remote is not a valid
  *          interface.
  * @return  -ENETUNREACH, if network defined by @p remote is not reachable.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -322,8 +322,9 @@ typedef struct sock_udp sock_udp_t;
  *         elsewhere
  * @return  -EAFNOSUPPORT, if `local != NULL` or `remote != NULL` and
  *          sock_udp_ep_t::family of @p local or @p remote is not supported.
- * @return  -EINVAL, if sock_udp_ep_t::netif of @p local or @p remote is not a
- *          valid interface or contradict each other (i.e.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::netif of @p local or @p remote are not a
+ *          valid interfaces or contradict each other (i.e.
  *          `(local->netif != remote->netif) &&
  *          ((local->netif != SOCK_ADDR_ANY_NETIF) ||
  *          (remote->netif != SOCK_ADDR_ANY_NETIF))` if neither is `NULL`).
@@ -420,6 +421,7 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  *          @p remote is != AF_UNSPEC and not supported.
  * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
  *          reachable.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
  * @return  -EINVAL, if sock_udp_ep_t::netif of @p remote is not a valid
  *          interface or contradicts the given local interface (i.e.
  *          neither the local end point of `sock` nor remote are assigned to


### PR DESCRIPTION
Hey Hauke,

I like to have commas on the last entry of a list. This makes future diffs cleaner when something is added to the list.

The only exception for not having a comma on the last entry is when that last entry is obvious the last. For example in the enum when the last entry is MAX- or LAST_something.
