### PR TITLE
stm32f2: addapt stm32f2 driver and nucleo-f207 board

### DIFF
--- a/boards/nucleo-f207/include/periph_conf.h
+++ b/boards/nucleo-f207/include/periph_conf.h
@@ -204,54 +204,32 @@ static const uart_conf_t uart_config[] = {
  * @name SPI configuration
  * @{
  */
-#define SPI_NUMOF           (2U)
-#define SPI_0_EN            1
-#define SPI_1_EN            1
-#define SPI_IRQ_PRIO        1
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .af       = 5,
+        .abpbus   = APB2,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_PIN(PORT_B, 2),
+        .af       = 5,
+        .abpbus   = APB1,
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+    }
+};
 
-/* SPI 0 device config */
-#define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
-#define SPI_0_BUS_DIV           1   /* 1 -> SPI bus runs with half CPU clock, 0 -> quarter CPU clock */
-#define SPI_0_IRQ               SPI1_IRQn
-#define SPI_0_IRQ_HANDLER       isr_spi1
-/* SPI 0 pin configuration */
-#define SPI_0_SCK_PORT          GPIOA       /* A5 pin is shared with the green LED. */
-#define SPI_0_SCK_PIN           5
-#define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define SPI_0_MISO_PORT         GPIOA
-#define SPI_0_MISO_PIN          6
-#define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define SPI_0_MOSI_PORT         GPIOA
-#define SPI_0_MOSI_PIN          7
-#define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_NUMOF               (sizeof(spi_config) / sizeof(spi_config[0]))
 
-/* SPI 1 device config */
-#define SPI_1_DEV               SPI2
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
-#define SPI_1_BUS_DIV           0   /* 1 -> SPI bus runs with half CPU clock, 0 -> quarter CPU clock */
-#define SPI_1_IRQ               SPI2_IRQn
-#define SPI_1_IRQ_HANDLER       isr_spi2
-/* SPI 1 pin configuration */
-#define SPI_1_SCK_PORT          GPIOB
-#define SPI_1_SCK_PIN           3
-#define SPI_1_SCK_AF            5
-#define SPI_1_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
-#define SPI_1_MISO_PORT         GPIOB
-#define SPI_1_MISO_PIN          4
-#define SPI_1_MISO_AF           5
-#define SPI_1_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
-#define SPI_1_MOSI_PORT         GPIOB
-#define SPI_1_MOSI_PIN          5
-#define SPI_1_MOSI_AF           5
-#define SPI_1_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
 /** @} */
-
 
 /**
  * @name I2C configuration

--- a/cpu/stm32f2/include/periph_cpu.h
+++ b/cpu/stm32f2/include/periph_cpu.h
@@ -190,6 +190,20 @@ typedef struct {
 } dac_conf_t;
 
 /**
+ * @brief   Structure for SPI configuration data
+ */
+typedef struct {
+    SPI_TypeDef *dev;       /**< SPI device base register address */
+    gpio_t mosi_pin;        /**< MOSI pin */
+    gpio_t miso_pin;        /**< MISO pin */
+    gpio_t sclk_pin;        /**< SCLK pin */
+    gpio_t cs_pin;          /**< HWCS pin, set to GPIO_UNDEF if not mapped */
+    gpio_af_t af;           /**< pin alternate function */
+    uint8_t abpbus;         /**< APB bus, 0 := APB1, 1:= APB2 */
+    uint32_t rccmask;       /**< bit in the RCC peripheral enable register */
+} spi_conf_t;
+
+/**
  * @brief   Configure the alternate function for the given pin
  *
  * @note    This is meant for internal use in STM32F2 peripheral drivers only

--- a/cpu/stm32f2/periph/spi.c
+++ b/cpu/stm32f2/periph/spi.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Hamburg University of Applied Sciences
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -16,6 +17,7 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Vincent Dupont <vincent@otakeys.com>
  *
  * @}
  */
@@ -29,427 +31,134 @@
 #include "thread.h"
 #include "sched.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
-
 /**
- * @brief Data-structure holding the state for a SPI device
+ * @brief   The STM32F2 only has one hardware chip select line
  */
-typedef struct {
-    char(*cb)(char data);
-} spi_state_t;
-
-static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev);
-
-/**
- * @brief Reserve memory for saving the SPI device's state
- */
-static spi_state_t spi_config[SPI_NUMOF];
-
-/* static bus div mapping */
-static const uint8_t spi_bus_div_map[SPI_NUMOF] = {
-#if SPI_0_EN
-    [SPI_0] = SPI_0_BUS_DIV,
-#endif
-#if SPI_1_EN
-    [SPI_1] = SPI_1_BUS_DIV,
-#endif
-#if SPI_2_EN
-    [SPI_2] = SPI_2_BUS_DIV,
-#endif
-};
+#define HWCS_LINE           (SPI_HWCS(0))
 
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
-static mutex_t locks[] =  {
-#if SPI_0_EN
-    [SPI_0] = MUTEX_INIT,
-#endif
-#if SPI_1_EN
-    [SPI_1] = MUTEX_INIT,
-#endif
-#if SPI_2_EN
-    [SPI_2] = MUTEX_INIT
-#endif
-};
+static mutex_t locks[SPI_NUMOF];
 
-int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
+static inline SPI_TypeDef *dev(spi_t bus)
 {
-    uint8_t speed_devider;
-    SPI_TypeDef *spi_port;
-
-    switch (speed) {
-        case SPI_SPEED_100KHZ:
-            return -2;          /* not possible for stm32f2, APB2 minimum is 328 kHz */
-            break;
-        case SPI_SPEED_400KHZ:
-            speed_devider = 0x05 + spi_bus_div_map[dev];  /* makes 656 kHz */
-            break;
-        case SPI_SPEED_1MHZ:
-            speed_devider = 0x04 + spi_bus_div_map[dev];  /* makes 1.3 MHz */
-            break;
-        case SPI_SPEED_5MHZ:
-            speed_devider = 0x02 + spi_bus_div_map[dev];  /* makes 5.3 MHz */
-            break;
-        case SPI_SPEED_10MHZ:
-            speed_devider = 0x01 + spi_bus_div_map[dev];  /* makes 10.5 MHz */
-            break;
-        default:
-            return -1;
-    }
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            /* enable clocks */
-            SPI_0_CLKEN();
-            SPI_0_SCK_PORT_CLKEN();
-            SPI_0_MISO_PORT_CLKEN();
-            SPI_0_MOSI_PORT_CLKEN();
-            break;
-#endif /* SPI_0_EN */
-#if SPI_1_EN
-        case SPI_1:
-            spi_port = SPI_1_DEV;
-            /* enable clocks */
-            SPI_1_CLKEN();
-            SPI_1_SCK_PORT_CLKEN();
-            SPI_1_MISO_PORT_CLKEN();
-            SPI_1_MOSI_PORT_CLKEN();
-            break;
-#endif /* SPI_1_EN */
-#if SPI_2_EN
-        case SPI_2:
-            spi_port = SPI_2_DEV;
-            /* enable clocks */
-            SPI_2_CLKEN();
-            SPI_2_SCK_PORT_CLKEN();
-            SPI_2_MISO_PORT_CLKEN();
-            SPI_2_MOSI_PORT_CLKEN();
-            break;
-#endif /* SPI_2_EN */
-        default:
-            return -2;
-    }
-
-    /* configure SCK, MISO and MOSI pin */
-    spi_conf_pins(dev);
-
-    /**************** SPI-Init *****************/
-    spi_port->I2SCFGR &= ~(SPI_I2SCFGR_I2SMOD);/* Activate the SPI mode (Reset I2SMOD bit in I2SCFGR register) */
-    spi_port->CR1 = 0;
-    spi_port->CR2 = 0;
-    /* the NSS (chip select) is managed purely by software */
-    spi_port->CR1 |= SPI_CR1_SSM | SPI_CR1_SSI;
-    spi_port->CR1 |= (speed_devider << 3);  /* Define serial clock baud rate. 001 leads to f_PCLK/4 */
-    spi_port->CR1 |= (SPI_CR1_MSTR);  /* 1: master configuration */
-    spi_port->CR1 |= (conf);
-    /* enable SPI */
-    spi_port->CR1 |= (SPI_CR1_SPE);
-    return 0;
+    return spi_config[bus].dev;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+void spi_init(spi_t bus)
 {
-    SPI_TypeDef *spi_port;
+    assert(bus < SPI_NUMOF);
 
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            /* enable clocks */
-            SPI_0_CLKEN();
-            SPI_0_SCK_PORT_CLKEN();
-            SPI_0_MISO_PORT_CLKEN();
-            SPI_0_MOSI_PORT_CLKEN();
-            /* configure interrupt channel */
-            NVIC_SetPriority(SPI_0_IRQ, SPI_IRQ_PRIO); /* set SPI interrupt priority */
-            NVIC_EnableIRQ(SPI_0_IRQ); /* set SPI interrupt priority */
-            break;
-#endif /* SPI_0_EN */
-#if SPI_1_EN
-        case SPI_1:
-            spi_port = SPI_1_DEV;
-            /* enable clocks */
-            SPI_1_CLKEN();
-            SPI_1_SCK_PORT_CLKEN();
-            SPI_1_MISO_PORT_CLKEN();
-            SPI_1_MOSI_PORT_CLKEN();
-            /* configure interrupt channel */
-            NVIC_SetPriority(SPI_1_IRQ, SPI_IRQ_PRIO);
-            NVIC_EnableIRQ(SPI_1_IRQ);
-            break;
-#endif /* SPI_1_EN */
-#if SPI_2_EN
-        case SPI_2:
-            spi_port = SPI_2_DEV;
-            /* enable clocks */
-            SPI_2_CLKEN();
-            SPI_2_SCK_PORT_CLKEN();
-            SPI_2_MISO_PORT_CLKEN();
-            SPI_2_MOSI_PORT_CLKEN();
-            /* configure interrupt channel */
-            NVIC_SetPriority(SPI_2_IRQ, SPI_IRQ_PRIO);
-            NVIC_EnableIRQ(SPI_2_IRQ);
-            break;
-#endif /* SPI_2_EN */
-        default:
-            return -1;
-    }
+    mutex_init(&locks[bus]);
 
-    /* configure sck, miso and mosi pin */
-    spi_conf_pins(dev);
-
-    /***************** SPI-Init *****************/
-    spi_port->I2SCFGR &= ~(SPI_I2SCFGR_I2SMOD);
-    spi_port->CR1 = 0;
-    spi_port->CR2 = 0;
-    /* enable RXNEIE flag to enable rx buffer not empty interrupt */
-    spi_port->CR2 |= (SPI_CR2_RXNEIE); /*1:not masked */
-    spi_port->CR1 |= (conf);
-     /* the NSS (chip select) is managed by software and NSS is low (slave enabled) */
-    spi_port->CR1 |= SPI_CR1_SSM;
-    /* set callback */
-    spi_config[dev].cb = cb;
-    /* enable SPI device */
-    spi_port->CR1 |= SPI_CR1_SPE;
-    return 0;
+    /* trigger pin initialization */
+    spi_init_pins(bus);
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_init_pins(spi_t bus)
 {
-    GPIO_TypeDef *port[3];
-    int pin[3], af[3];
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            port[0] = SPI_0_SCK_PORT;
-            pin[0] = SPI_0_SCK_PIN;
-            af[0] = SPI_0_SCK_AF;
-            port[1] = SPI_0_MOSI_PORT;
-            pin[1] = SPI_0_MOSI_PIN;
-            af[1] = SPI_0_MOSI_AF;
-            port[2] = SPI_0_MISO_PORT;
-            pin[2] = SPI_0_MISO_PIN;
-            af[2] = SPI_0_MISO_AF;
-            break;
-#endif /* SPI_0_EN */
-#if SPI_1_EN
-        case SPI_1:
-            port[0] = SPI_1_SCK_PORT;
-            pin[0] = SPI_1_SCK_PIN;
-            af[0] = SPI_1_SCK_AF;
-            port[1] = SPI_1_MOSI_PORT;
-            pin[1] = SPI_1_MOSI_PIN;
-            af[1] = SPI_1_MOSI_AF;
-            port[2] = SPI_1_MISO_PORT;
-            pin[2] = SPI_1_MISO_PIN;
-            af[2] = SPI_1_MISO_AF;
-            break;
-#endif /* SPI_1_EN */
-#if SPI_2_EN
-        case SPI_2:
-            port[0] = SPI_2_SCK_PORT;
-            pin[0] = SPI_2_SCK_PIN;
-            af[0] = SPI_2_SCK_AF;
-            port[1] = SPI_2_MOSI_PORT;
-            pin[1] = SPI_2_MOSI_PIN;
-            af[1] = SPI_2_MOSI_AF;
-            port[2] = SPI_2_MISO_PORT;
-            pin[2] = SPI_2_MISO_PIN;
-            af[2] = SPI_2_MISO_AF;
-            break;
-#endif /* SPI_2_EN */
-        default:
-            return -1;
-    }
-
-    /***************** GPIO-Init *****************/
-    for (int i = 0; i < 3; i++) {
-        /* Set GPIOs to AF mode */
-        port[i]->MODER &= ~(3 << (2 * pin[i]));
-        port[i]->MODER |= (2 << (2 * pin[i]));
-        /* Set speed */
-        port[i]->OSPEEDR &= ~(3 << (2 * pin[i]));
-        port[i]->OSPEEDR |= (3 << (2 * pin[i]));
-        /* Set to push-pull configuration */
-        port[i]->OTYPER &= ~(1 << pin[i]);
-        /* Configure push-pull resistors */
-        port[i]->PUPDR &= ~(3 << (2 * pin[i]));
-        port[i]->PUPDR |= (2 << (2 * pin[i]));
-        /* Configure GPIOs for the SPI alternate function */
-        int hl = (pin[i] < 8) ? 0 : 1;
-        port[i]->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
-        port[i]->AFR[hl] |= (af[i] << ((pin[i] - (hl * 8)) * 4));
-    }
-
-    return 0;
+    gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
+    gpio_init(spi_config[bus].miso_pin, GPIO_IN);
+    gpio_init(spi_config[bus].sclk_pin, GPIO_OUT);
+    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].af);
+    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].af);
+    gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].af);
 }
 
-int spi_acquire(spi_t dev)
+int spi_init_cs(spi_t bus, spi_cs_t cs)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
+    if (bus >= SPI_NUMOF) {
+        return SPI_NODEV;
     }
-    mutex_lock(&locks[dev]);
-    return 0;
-}
-
-int spi_release(spi_t dev)
-{
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
-    mutex_unlock(&locks[dev]);
-    return 0;
-}
-
-int spi_transfer_byte(spi_t dev, char out, char *in)
-{
-    SPI_TypeDef *spi_port;
-
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            spi_port = SPI_0_DEV;
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            spi_port = SPI_1_DEV;
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            spi_port = SPI_2_DEV;
-            break;
-#endif
-        default:
-            return -1;
+    if (cs == GPIO_UNDEF) {
+        return SPI_NOCS;
     }
 
-    while (!(spi_port->SR & SPI_SR_TXE));
-    spi_port->DR = out;
-
-    while (!(spi_port->SR & SPI_SR_RXNE));
-
-    if (in != NULL) {
-        *in = spi_port->DR;
+    if (cs == HWCS_LINE) {
+        gpio_init((gpio_t)spi_config[bus].cs_pin, GPIO_OUT);
+        gpio_init_af((gpio_t)spi_config[bus].cs_pin, spi_config[bus].af);
     }
     else {
-        spi_port->DR;
+        gpio_init((gpio_t)cs, GPIO_OUT);
+        gpio_set((gpio_t)cs);
     }
 
-    return 1;
+    return SPI_OK;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
+    /* check device and clock speed for validity */
+    assert(bus < SPI_NUMOF && clk <= 0x0f);
 
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            SPI_0_DEV->DR = reset_val;
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            SPI_1_DEV->DR = reset_val;
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            SPI_2_DEV->DR = reset_val;
-            break;
-#endif
+    /* lock bus */
+    mutex_lock(&locks[bus]);
+    /* enable SPI device clock */
+    periph_clk_en(spi_config[bus].abpbus, spi_config[bus].rccmask);
+    /* enable device */
+    dev(bus)->CR1 = (((clk + spi_config[bus].abpbus) << 3) | mode | SPI_CR1_MSTR);
+    dev(bus)->CR2 = 0;
+    if (cs != HWCS_LINE) {
+        dev(bus)->CR1 |= (SPI_CR1_SSM | SPI_CR1_SSI);
+    }
+    else {
+        dev(bus)->CR2 |= (SPI_CR2_SSOE);
+    }
+
+    return SPI_OK;
+}
+
+void spi_release(spi_t bus)
+{
+    /* disable device and release lock */
+    dev(bus)->CR1 = 0;
+    periph_clk_dis(spi_config[bus].abpbus, spi_config[bus].rccmask);
+    mutex_unlock(&locks[bus]);
+}
+
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        const void *out, void *in, size_t len)
+{
+    uint8_t *inbuf = (uint8_t *)in;
+    uint8_t *outbuf = (uint8_t *)out;
+
+    /* make sure at least one input or one output buffer is given */
+    assert(outbuf || inbuf);
+
+    /* active the given chip select line */
+    dev(bus)->CR1 |= (SPI_CR1_SPE);     /* this pulls the HW CS line low */
+    if ((cs != HWCS_LINE) && (cs != GPIO_UNDEF)) {
+        gpio_clear((gpio_t)cs);
+    }
+
+    /* transfer data, use shortpath if only sending data */
+    if (!inbuf) {
+        for (size_t i = 0; i < len; i++) {
+            while (!(dev(bus)->SR & SPI_SR_TXE));
+            dev(bus)->DR = outbuf[i];
+        }
+    }
+    else {
+        for (size_t i = 0; i < len; i++) {
+            uint8_t tmp = (outbuf) ? outbuf[i] : 0;
+            while (!(dev(bus)->SR & SPI_SR_TXE));
+            dev(bus)->DR = tmp;
+            while (!(dev(bus)->SR & SPI_SR_RXNE));
+            inbuf[i] = dev(bus)->DR;
+        }
+    }
+
+    /* release the chip select if not specified differently */
+    if ((!cont) && (cs != GPIO_UNDEF)) {
+        if (cs != HWCS_LINE) {
+            gpio_set((gpio_t)cs);
+        }
+        else {
+            dev(bus)->CR1 &= ~(SPI_CR1_SPE);    /* pull HW CS line high */
+        }
     }
 }
-
-void spi_poweron(spi_t dev)
-{
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            SPI_0_CLKEN();
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            SPI_1_CLKEN();
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            SPI_2_CLKEN();
-            break;
-#endif
-    }
-}
-
-void spi_poweroff(spi_t dev)
-{
-    switch (dev) {
-#if SPI_0_EN
-        case SPI_0:
-            while (SPI_0_DEV->SR & SPI_SR_BSY);
-            SPI_0_CLKDIS();
-            break;
-#endif
-#if SPI_1_EN
-        case SPI_1:
-            while (SPI_1_DEV->SR & SPI_SR_BSY);
-            SPI_1_CLKDIS();
-            break;
-#endif
-#if SPI_2_EN
-        case SPI_2:
-            while (SPI_2_DEV->SR & SPI_SR_BSY);
-            SPI_2_CLKDIS();
-            break;
-#endif
-    }
-}
-
-static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
-{
-
-    if (spi->SR & SPI_SR_RXNE) {
-        char data;
-        data = spi->DR;
-        data = spi_config[dev].cb(data);
-        spi->DR = data;
-    }
-    /* see if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-
-#if SPI_0_EN
-void SPI_0_IRQ_HANDLER(void)
-{
-    irq_handler_transfer(SPI_0_DEV, SPI_0);
-}
-#endif
-
-#if SPI_1_EN
-void SPI_1_IRQ_HANDLER(void)
-{
-    irq_handler_transfer(SPI_1_DEV, SPI_1);
-}
-#endif
-
-#if SPI_2_EN
-void SPI_2_IRQ_HANDLER(void)
-{
-    irq_handler_transfer(SPI_2_DEV, SPI_2);
-}
-#endif
-
-#endif /* SPI_NUMOF */


### PR DESCRIPTION
Hi,

This is the spi driver for stm32f2.
It's almost a copy of the one from stm32f4 with some minor changes, maybe we could have a generic driver, but I don't have the time right now to study all the family :)

I'm not able to have the hardware chip select working from the tests I've made...
I wanted to propose a DMA version, but it's too much work and has impact on uart driver, so it will come later on.

