### PR TITLE
stm32_common: add UART HW flow control

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -150,6 +150,13 @@ typedef struct {
     uint8_t dma_stream;     /**< DMA stream used for TX */
     uint8_t dma_chan;       /**< DMA channel used for TX */
 #endif
+#ifdef UART_USE_HW_FC
+    uint8_t hw_flow_ctrl;   /**< use HW flow control flag */
+    gpio_t cts_pin;         /**< CTS pin */
+    gpio_t rts_pin;         /**< RTS pin */
+    gpio_af_t cts_af;       /**< alternate function for CTS pin */
+    gpio_af_t rts_af;       /**< alternate function for RTS pin */
+#endif
 } uart_conf_t;
 
 /**

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -67,6 +67,18 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     gpio_init_af(uart_config[uart].tx_pin, uart_config[uart].tx_af);
     gpio_init_af(uart_config[uart].rx_pin, uart_config[uart].rx_af);
 #endif
+#ifdef UART_USE_HW_FC
+    if (uart_config[uart].hw_flow_ctrl) {
+        gpio_init(uart_config[uart].cts_pin, GPIO_IN);
+        gpio_init(uart_config[uart].rts_pin, GPIO_OUT);
+#ifdef CPU_FAM_STM32F1
+        gpio_init_af(uart_config[uart].rts_pin, GPIO_AF_OUT_PP);
+#else
+        gpio_init_af(uart_config[uart].cts_pin, uart_config[uart].cts_af);
+        gpio_init_af(uart_config[uart].rts_pin, uart_config[uart].rts_af);
+#endif
+    }
+#endif
 
     /* enable the clock */
     periph_clk_en(uart_config[uart].bus, uart_config[uart].rcc_mask);
@@ -90,6 +102,13 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     else {
         dev(uart)->CR1 = (USART_CR1_UE | USART_CR1_TE);
     }
+
+#ifdef UART_USE_HW_FC
+    if (uart_config[uart].hw_flow_ctrl) {
+        /* configure hardware flow control */
+        dev(uart)->CR3 = (USART_CR3_RTSE | USART_CR3_CTSE);
+    }
+#endif
 
     return UART_OK;
 }


### PR DESCRIPTION
This adds back HW flow control support in the UART driver. It's optional and compiled only if `UART_USE_HW_FC` is defined.

Tested on nucleo-f207.
Compile test OK for all boards.

I'm not sure about the stm32f1 specific code.