### PR TITLE
RIOT PR 8920 fixes

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -465,8 +465,8 @@ size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type
  *
  * @return      number of bytes written to @p buf
  */
-size_t coap_opt_put_string_raw(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
-                               const char *string, char separator);
+size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
+                           const char *string, char separator);
 
 /**
  * @brief   Convenience function for inserting URI_PATH option into buffer
@@ -478,10 +478,10 @@ size_t coap_opt_put_string_raw(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
  *
  * @returns     amount of bytes written to @p buf
  */
-static inline size_t coap_opt_put_uri_path_raw(uint8_t *buf, uint16_t lastonum,
-                                               const char *uri)
+static inline size_t coap_opt_put_uri_path(uint8_t *buf, uint16_t lastonum,
+                                           const char *uri)
 {
-    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_URI_PATH, uri, '/');
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_URI_PATH, uri, '/');
 }
 
 /**
@@ -494,10 +494,10 @@ static inline size_t coap_opt_put_uri_path_raw(uint8_t *buf, uint16_t lastonum,
  *
  * @returns     amount of bytes written to @p buf
  */
-static inline size_t coap_opt_put_uri_query_raw(uint8_t *buf, uint16_t lastonum,
-                                                const char *uri)
+static inline size_t coap_opt_put_uri_query(uint8_t *buf, uint16_t lastonum,
+                                            const char *uri)
 {
-    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_URI_QUERY, uri, '&');
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_URI_QUERY, uri, '&');
 }
 
 /**
@@ -510,12 +510,12 @@ static inline size_t coap_opt_put_uri_query_raw(uint8_t *buf, uint16_t lastonum,
  *
  * @returns     amount of bytes written to @p buf
  */
-static inline size_t coap_opt_put_location_path_raw(uint8_t *buf,
-                                                    uint16_t lastonum,
-                                                    const char *location)
+static inline size_t coap_opt_put_location_path(uint8_t *buf,
+                                                uint16_t lastonum,
+                                                const char *location)
 {
-    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_LOCATION_PATH,
-                                   location, '/');
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_LOCATION_PATH,
+                               location, '/');
 }
 
 /**
@@ -528,12 +528,12 @@ static inline size_t coap_opt_put_location_path_raw(uint8_t *buf,
  *
  * @returns     amount of bytes written to @p buf
  */
-static inline size_t coap_opt_put_location_query_raw(uint8_t *buf,
-                                                     uint16_t lastonum,
-                                                     const char *location)
+static inline size_t coap_opt_put_location_query(uint8_t *buf,
+                                                 uint16_t lastonum,
+                                                 const char *location)
 {
-    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_LOCATION_QUERY,
-                                   location, '&');
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_LOCATION_QUERY,
+                               location, '&');
 }
 
 /**
@@ -647,24 +647,6 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value);
  * @return        total number of bytes written to buffer
  */
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
-
-/**
- * @brief   Insert LOCATION_PATH option into buffer
- *
- * @param[out]  buf         buffer to write to
- * @param[in]   lastonum    number of previous option (for delta calculation),
- *                          or 0 if first option
- * @param[in]   uri         location path
- *
- * @returns     amount of bytes written to @p buf
- */
-static inline size_t coap_put_option_location_path(uint8_t *buf,
-                                                   uint16_t lastonum,
-                                                   const char *loc_path)
-{
-    return coap_put_option_string(buf, lastonum, COAP_OPT_LOCATION_PATH,
-                                  loc_path, '/');
-}
 
 /**
  * @brief   Get content type from packet

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -692,7 +692,7 @@ ssize_t coap_opt_get_string(const coap_pkt_t *pkt, uint16_t optnum,
  * @returns     -ENOSPC     if URI option is larger than NANOCOAP_URI_MAX
  * @returns     nr of bytes written to @p target (including '\0')
  */
-static inline ssize_t coap_opt_get_uri_path(const coap_pkt_t *pkt,
+static inline ssize_t coap_get_uri_path(const coap_pkt_t *pkt,
                                             uint8_t *target)
 {
     return coap_opt_get_string(pkt, COAP_OPT_URI_PATH, target,
@@ -713,7 +713,7 @@ static inline ssize_t coap_opt_get_uri_path(const coap_pkt_t *pkt,
  * @returns     -ENOSPC     if URI option is larger than NANOCOAP_URI_MAX
  * @returns     nr of bytes written to @p target (including '\0')
  */
-static inline ssize_t coap_opt_get_uri_query(const coap_pkt_t *pkt,
+static inline ssize_t coap_get_uri_query(const coap_pkt_t *pkt,
                                              uint8_t *target)
 {
     return coap_opt_get_string(pkt, COAP_OPT_URI_QUERY, target,
@@ -735,7 +735,7 @@ static inline ssize_t coap_opt_get_uri_query(const coap_pkt_t *pkt,
  * @returns     -ENOSPC     if URI option is larger than @p max_len
  * @returns     nr of bytes written to @p target (including '\0')
  */
-static inline ssize_t coap_opt_get_location_path(const coap_pkt_t *pkt,
+static inline ssize_t coap_get_location_path(const coap_pkt_t *pkt,
                                                  uint8_t *target, size_t max_len)
 {
     return coap_opt_get_string(pkt, COAP_OPT_LOCATION_PATH,
@@ -757,7 +757,7 @@ static inline ssize_t coap_opt_get_location_path(const coap_pkt_t *pkt,
  * @returns     -ENOSPC     if URI option is larger than @p max_len
  * @returns     nr of bytes written to @p target (including '\0')
  */
-static inline ssize_t coap_opt_get_location_query(const coap_pkt_t *pkt,
+static inline ssize_t coap_get_location_query(const coap_pkt_t *pkt,
                                                   uint8_t *target,
                                                   size_t max_len)
 {

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -454,6 +454,89 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 
 /**
+ * @brief   Encode the given string as multi-part option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   optnum      option number to use
+ * @param[in]   string      string to encode as option
+ * @param[in]   separator   character used in @p string to separate parts
+ *
+ * @return      number of bytes written to @p buf
+ */
+size_t coap_opt_put_string_raw(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
+                               const char *string, char separator);
+
+/**
+ * @brief   Convenience function for inserting URI_PATH option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   uri         ptr to source URI
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_uri_path_raw(uint8_t *buf, uint16_t lastonum,
+                                               const char *uri)
+{
+    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_URI_PATH, uri, '/');
+}
+
+/**
+ * @brief   Convenience function for inserting URI_QUERY option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   uri         ptr to source URI
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_uri_query_raw(uint8_t *buf, uint16_t lastonum,
+                                                const char *uri)
+{
+    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_URI_QUERY, uri, '&');
+}
+
+/**
+ * @brief   Convenience function for inserting LOCATION_PATH option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   uri         ptr to string holding the location
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_location_path_raw(uint8_t *buf,
+                                                    uint16_t lastonum,
+                                                    const char *location)
+{
+    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_LOCATION_PATH,
+                                   location, '/');
+}
+
+/**
+ * @brief   Convenience function for inserting LOCATION_QUERY option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   uri         ptr to string holding the location
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_location_query_raw(uint8_t *buf,
+                                                     uint16_t lastonum,
+                                                     const char *location)
+{
+    return coap_opt_put_string_raw(buf, lastonum, COAP_OPT_LOCATION_QUERY,
+                                   location, '&');
+}
+
+/**
  * @brief    Generic block option getter
  *
  * @param[in]   pkt     pkt to work on
@@ -527,16 +610,15 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
  * @post pkt.payload advanced to first byte after option(s)
  * @post pkt.payload_len reduced by option(s) length
  *
- * @param[in,out] pkt       pkt referencing target buffer
- * @param[in]     optnum    option number to use
- * @param[in]     string    string to encode as option
- * @param[in]     separator character used in @p string to separate parts
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     optnum      option number to use
+ * @param[in]     string      string to encode as option
+ * @param[in]     separator   character used in @p string to separate parts
  *
  * @return        number of bytes written to buffer
  * @return        -ENOSPC if no available options
  */
-ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum,
-                            const char *string, char separator);
+ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string, char separator);
 
 /**
  * @brief   Encode the given uint option into pkt
@@ -544,69 +626,14 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum,
  * @post pkt.payload advanced to first byte after option
  * @post pkt.payload_len reduced by option length
  *
- * @param[in,out] pkt       pkt referencing target buffer
- * @param[in]     optnum    option number to use
- * @param[in]     value     uint to encode
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     optnum      option number to use
+ * @param[in]     value       uint to encode
  *
  * @return        number of bytes written to buffer
  * @return        <0 reserved for error but not implemented yet
  */
 ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value);
-
-/**
- * @brief   Convenience function for adding URI_PATH option to packet
- *
- * @param[in,out] pkt       pkt referencing target buffer
- * @param[in] uri           ptr to URI path string
- *
- * @returns     amount of bytes written to @p buf
- */
-static inline size_t coap_opt_add_uri_path(coap_pkt_t *pkt, const char *uri)
-{
-    return coap_opt_add_string(pkt, COAP_OPT_URI_PATH, uri, '/');
-}
-
-/**
- * @brief   Convenience function for adding URI_QUERY option to packet
- *
- * @param[in,out] pkt       pkt referencing target buffer
- * @param[in] uri           ptr to URI query string
- *
- * @returns     amount of bytes written to @p buf
- */
-static inline size_t coap_opt_add_uri_query(coap_pkt_t *pkt, const char *uri)
-{
-    return coap_opt_add_string(pkt, COAP_OPT_URI_QUERY, uri, '&');
-}
-
-/**
- * @brief   Convenience function for adding LOCATION_PATH option to packet
- *
- * @param[in,out] pkt           pkt referencing target buffer
- * @param[in] location_path     ptr to string holding the location path string
- *
- * @returns     amount of bytes written to @p buf
- */
-static inline size_t coap_opt_add_location_path(coap_pkt_t *pkt,
-                                                const char *location_path)
-{
-    return coap_opt_add_string(pkt, COAP_OPT_LOCATION_PATH, location_path, '/');
-}
-
-/**
- * @brief   Convenience function for adding LOCATION_QUERY option to packet
- *
- * @param[in,out] pkt           pkt referencing target buffer
- * @param[in] location_query    ptr to string holding the location query string
- *
- * @returns     amount of bytes written to @p buf
- */
-static inline size_t coap_opt_add_location_query(coap_pkt_t *pkt,
-                                                 const char *location_query)
-{
-    return coap_opt_add_string(pkt, COAP_OPT_LOCATION_QUERY,
-                               location_query, '&');
-}
 
 /**
  * @brief   Finalizes options as required and prepares for payload
@@ -620,6 +647,24 @@ static inline size_t coap_opt_add_location_query(coap_pkt_t *pkt,
  * @return        total number of bytes written to buffer
  */
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
+
+/**
+ * @brief   Insert LOCATION_PATH option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   uri         location path
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_put_option_location_path(uint8_t *buf,
+                                                   uint16_t lastonum,
+                                                   const char *loc_path)
+{
+    return coap_put_option_string(buf, lastonum, COAP_OPT_LOCATION_PATH,
+                                  loc_path, '/');
+}
 
 /**
  * @brief   Get content type from packet

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -564,8 +564,8 @@ static ssize_t _write_options(coap_pkt_t *pdu, uint8_t *buf, size_t len)
                 DEBUG("gcoap: _write_options: path does not start with '/'\n");
                 return -EINVAL;
             }
-            bufpos += coap_opt_put_uri_path_raw(bufpos, last_optnum,
-                                                (char *)pdu->url);
+            bufpos += coap_opt_put_uri_path(bufpos, last_optnum,
+                                            (char *)pdu->url);
             last_optnum = COAP_OPT_URI_PATH;
         }
     }
@@ -578,8 +578,8 @@ static ssize_t _write_options(coap_pkt_t *pdu, uint8_t *buf, size_t len)
 
     /* Uri-query for requests */
     if (coap_get_code_class(pdu) == COAP_CLASS_REQ) {
-        bufpos += coap_opt_put_uri_query_raw(bufpos, last_optnum,
-                                             (char *)pdu->qs);
+        bufpos += coap_opt_put_uri_query(bufpos, last_optnum,
+                                         (char *)pdu->qs);
         /* uncomment when further options are added below ... */
         /* last_optnum = COAP_OPT_URI_QUERY; */
     }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -119,7 +119,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
 #ifdef MODULE_GCOAP
-    coap_opt_get_uri_path(pkt, pkt->url);
+    coap_get_uri_path(pkt, pkt->url);
     pkt->content_type = coap_get_content_type(pkt);
 
     if (coap_get_option_uint(pkt, COAP_OPT_OBSERVE, &pkt->observe_value) != 0) {
@@ -304,7 +304,7 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
     uint8_t *uri = pkt->url;
 #else
     uint8_t uri[NANOCOAP_URI_MAX];
-    if (coap_opt_get_uri_query(pkt, uri) <= 0) {
+    if (coap_get_uri_query(pkt, uri) <= 0) {
         return -EBADMSG;
     }
 #endif

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -119,7 +119,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
 #ifdef MODULE_GCOAP
-    coap_opt_get_uri_query(pkt, pkt->url);
+    coap_opt_get_uri_path(pkt, pkt->url);
     pkt->content_type = coap_get_content_type(pkt);
 
     if (coap_get_option_uint(pkt, COAP_OPT_OBSERVE, &pkt->observe_value) != 0) {
@@ -577,8 +577,8 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
     }
 }
 
-size_t coap_opt_put_string_raw(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
-                               const char *string, char separator)
+size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
+                           const char *string, char separator)
 {
     size_t len = strlen(string);
 

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -44,11 +44,11 @@ static void test_nanocoap__hdr(void)
 
     TEST_ASSERT_EQUAL_INT(msgid, coap_get_id(&pkt));
 
-    int res = coap_opt_get_uri_path(&pkt, path_tmp);
+    int res = coap_get_uri_path(&pkt, path_tmp);
     TEST_ASSERT_EQUAL_INT(sizeof(path), res);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)path_tmp);
 
-    res = coap_opt_get_location_path(&pkt, path_tmp, 64);
+    res = coap_get_location_path(&pkt, path_tmp, 64);
     TEST_ASSERT_EQUAL_INT(sizeof(loc_path), res);
     TEST_ASSERT_EQUAL_STRING((char *)loc_path, (char *)path_tmp);
 }
@@ -83,7 +83,7 @@ static void test_nanocoap__get_req(void)
     TEST_ASSERT_EQUAL_INT(total_opt_len, len);
 
     char uri[10] = {0};
-    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 
     len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
@@ -147,7 +147,7 @@ static void test_nanocoap__get_multi_path(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[10] = {0};
-    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
@@ -169,7 +169,7 @@ static void test_nanocoap__get_root_path(void)
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
 
     char uri[10] = {0};
-    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
@@ -195,13 +195,13 @@ static void test_nanocoap__get_max_path(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[NANOCOAP_URI_MAX] = {0};
-    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
 /*
  * Builds on get_req test, to test path longer than NANOCOAP_URI_MAX. We
- * expect coap_opt_get_uri_path() to return -ENOSPC.
+ * expect coap_get_uri_path() to return -ENOSPC.
  */
 static void test_nanocoap__get_path_too_long(void)
 {
@@ -222,7 +222,7 @@ static void test_nanocoap__get_path_too_long(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[NANOCOAP_URI_MAX] = {0};
-    int get_len = coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
+    int get_len = coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_INT(-ENOSPC, get_len);
 }
 

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -36,8 +36,8 @@ static void test_nanocoap__hdr(void)
     uint8_t *pktpos = &buf[0];
     pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_REQ, NULL, 0,
                              COAP_METHOD_GET, msgid);
-    pktpos += coap_opt_put_location_path_raw(pktpos, 0, loc_path);
-    pktpos += coap_opt_put_uri_path_raw(pktpos, COAP_OPT_LOCATION_PATH, path);
+    pktpos += coap_opt_put_location_path(pktpos, 0, loc_path);
+    pktpos += coap_opt_put_uri_path(pktpos, COAP_OPT_LOCATION_PATH, path);
 
     coap_pkt_t pkt;
     coap_parse(&pkt, &buf[0], pktpos - &buf[0]);
@@ -83,7 +83,7 @@ static void test_nanocoap__get_req(void)
     TEST_ASSERT_EQUAL_INT(total_opt_len, len);
 
     char uri[10] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 
     len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
@@ -147,7 +147,7 @@ static void test_nanocoap__get_multi_path(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[10] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
@@ -169,7 +169,7 @@ static void test_nanocoap__get_root_path(void)
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
 
     char uri[10] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
@@ -195,13 +195,13 @@ static void test_nanocoap__get_max_path(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[NANOCOAP_URI_MAX] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
 /*
  * Builds on get_req test, to test path longer than NANOCOAP_URI_MAX. We
- * expect coap_get_uri() to return -ENOSPC.
+ * expect coap_opt_get_uri_path() to return -ENOSPC.
  */
 static void test_nanocoap__get_path_too_long(void)
 {
@@ -222,7 +222,7 @@ static void test_nanocoap__get_path_too_long(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[NANOCOAP_URI_MAX] = {0};
-    int get_len = coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    int get_len = coap_opt_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_INT(-ENOSPC, get_len);
 }
 


### PR DESCRIPTION
### Contribution description
Fixes to make PR 8920 ready to merge. Commit details:

- 31daaeb -- Revert hauke's 61e3066 commit from earlier today
- 4e133fe -- Convert coap_opt_put_xxx_raw() to coap_opt_put_xxx().
- d3d54ed -- Convert coap_opt_get_xxx() to coap_get_xxx(), except for coap_opt_get_string(). 

PR 9085 added these functions:
- coap_pkt_init()
- coap_opt_add_string()
- coap_opt_add_uint()
- coap_opt_finish()

All of these functions require a coap_pkt_t* parameter. Our design was to extend this to create functions in the form coap_opt_put_xxx() for the traditional/minimal approach, which includes a uint8_t \*buffer rather than a coap_pkt_t. That is why I added commit 4e133fe. To be clear, coap_opt_add_xxx() is used when the parameter is a coap_pkt_t. So, there should be two forms for any given option write function -- coap_opt_add_xxx(coap_pkt_t*) and coap_opt_put_xxx(uint8_t*).

This PR does not include coap_opt_add_xxx() functions, like coap_opt_add_uri_path(), only the coap_opt_put_xxx() form. We can add the coap_opt_add_xxx() functions in a follow-on PR.

We created PR 9085 because it allows us to keep read the packet while it is being built, and provides a more convenient way to add options. The caller does not need to remember the last option number added. In addition, gcoap uses the coap_opt_add_xxx() functions. In fact, PR 9156 transitions gcoap to use these functions. When that PR is merged, it removes the extra 130 bytes in the coap_pkt_t struct for the url and qs attributes.

One other minor note -- once we merge 8920, we can refactor coap_opt_add_string() to reuse coap_opt_put_string() to remove the code duplication.

Commit d3d54ed removes the 'opt' in the coap_opt_get_xxx() functions (except coap_opt_get_string()). I did this because I don't think the 'opt' in the function name really adds anything. All of the 'get' functions already have a coap_pkt_t* available. Let me know what you think.

Finally, are you concerned that this PR removes coap_get_uri() and coap_put_option_uri()? Should we create shim functions (marked 'deprecated') with these names that use the new functions internally? The issue here is with existing implementations that use these functions. They will break once this PR is merged.

### Issues/PRs references

RIOT PR #8920