### PR TITLE
Remove casting of sizeof

### DIFF
--- a/tests/bench_sizeof_coretypes/main.c
+++ b/tests/bench_sizeof_coretypes/main.c
@@ -40,7 +40,7 @@
 
 
 #define P(NAME) printf("    tcb->%-11s            %3zu     %3u\n", #NAME, \
-                       (unsigned)sizeof(((thread_t *) 0)->NAME), \
+                       sizeof(((thread_t *) 0)->NAME), \
                        (unsigned)offsetof(thread_t, NAME))
 
 int main(void)


### PR DESCRIPTION
Format string is now using the "z" length field, which means it's
expecting a size_t sized integer.

This is a fixup for https://github.com/RIOT-OS/RIOT/pull/9346.