### PR TITLE
net/gcoap for RIOT #9857: adapt cord examples and update documentation

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -185,7 +185,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
         return 0;
     }
 
-    bytes_sent = gcoap_req_send2(buf, len, &remote, _resp_handler);
+    bytes_sent = gcoap_req_send2(buf, len, &remote, _resp_handler, NULL);
     if (bytes_sent > 0) {
         req_count++;
     }

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -29,8 +29,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
-                          sock_udp_ep_t *remote);
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                          const sock_udp_ep_t *remote);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
@@ -52,16 +52,16 @@ static uint16_t req_count = 0;
 /*
  * Response callback.
  */
-static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
-                          sock_udp_ep_t *remote)
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                          const sock_udp_ep_t *remote)
 {
     (void)remote;       /* not interested in the source currently */
 
-    if (req_state == GCOAP_MEMO_TIMEOUT) {
+    if (memo->state == GCOAP_MEMO_TIMEOUT) {
         printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
         return;
     }
-    else if (req_state == GCOAP_MEMO_ERR) {
+    else if (memo->state == GCOAP_MEMO_ERR) {
         printf("gcoap: error in response\n");
         return;
     }

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -119,8 +119,8 @@
  *
  * Here is the expected sequence for handling a response in the callback.
  *
- * -# Test for a server response or timeout in the _req_state_ callback
- *    parameter. See the GCOAP_MEMO... constants.
+ * -# Test for a server response or timeout in the `state` field of the `memo`
+ *    callback parameter (`memo->state`). See the GCOAP_MEMO... constants.
  * -# Test the response with coap_get_code_class() and coap_get_code_detail().
  * -# Test the response payload with the coap_pkt_t _payload_len_ and
  *    _content_type_ attributes.
@@ -441,13 +441,20 @@ typedef struct gcoap_listener {
 } gcoap_listener_t;
 
 /**
+ * @brief   Forward declaration of the request memo type
+ *
+ */
+typedef struct gcoap_request_memo gcoap_request_memo_t;
+
+/**
  * @brief   Handler function for a server response, including the state for the
  *          originating request
  *
  * If request timed out, the packet header is for the request.
  */
-typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
-                                     sock_udp_ep_t *remote);
+typedef void (*gcoap_resp_handler_t)(const gcoap_request_memo_t *memo,
+                                     coap_pkt_t* pdu,
+                                     const sock_udp_ep_t *remote);
 
 /**
  * @brief  Extends request memo for resending a confirmable request.
@@ -460,7 +467,7 @@ typedef struct {
 /**
  * @brief   Memo to handle a response for a request
  */
-typedef struct {
+struct gcoap_request_memo {
     unsigned state;                     /**< State of this memo, a GCOAP_MEMO... */
     int send_limit;                     /**< Remaining resends, 0 if none;
                                              GCOAP_SEND_LIMIT_NON if non-confirmable */
@@ -474,7 +481,7 @@ typedef struct {
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
     xtimer_t response_timer;            /**< Limits wait for response */
     msg_t timeout_msg;                  /**< For response timer */
-} gcoap_request_memo_t;
+};
 
 /**
  * @brief   Memo for Observe registration and notifications

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -442,7 +442,6 @@ typedef struct gcoap_listener {
 
 /**
  * @brief   Forward declaration of the request memo type
- *
  */
 typedef struct gcoap_request_memo gcoap_request_memo_t;
 
@@ -451,6 +450,12 @@ typedef struct gcoap_request_memo gcoap_request_memo_t;
  *          originating request
  *
  * If request timed out, the packet header is for the request.
+ *
+ * Parameters:
+ * - memo    Tracks request for timeout and response generation (read only);
+ *           public members: state, send_limit, remote_ep, context
+ * - pdu     Incoming response
+ * - remote  Origin of response (read only)
  */
 typedef void (*gcoap_resp_handler_t)(const gcoap_request_memo_t *memo,
                                      coap_pkt_t* pdu,

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -479,6 +479,7 @@ struct gcoap_request_memo {
                                              supports resending message */
     sock_udp_ep_t remote_ep;            /**< Remote endpoint */
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
+    void *context;                      /**< ptr to user defined context data */
     xtimer_t response_timer;            /**< Limits wait for response */
     msg_t timeout_msg;                  /**< For response timer */
 };
@@ -572,13 +573,14 @@ static inline ssize_t gcoap_request(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  * @param[in] len           Length of the buffer
  * @param[in] remote        Destination for the packet
  * @param[in] resp_handler  Callback when response received, may be NULL
+ * @param[in] context       User defined context passed to the response handler
  *
  * @return  length of the packet
  * @return  0 if cannot send
  */
 size_t gcoap_req_send2(const uint8_t *buf, size_t len,
                        const sock_udp_ep_t *remote,
-                       gcoap_resp_handler_t resp_handler);
+                       gcoap_resp_handler_t resp_handler, void *context);
 
 /**
  * @brief  Sends a buffer containing a CoAP request to the provided host/port
@@ -590,12 +592,14 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
  * @param[in] addr          Destination for the packet
  * @param[in] port          Port at the destination
  * @param[in] resp_handler  Callback when response received, may be NULL
+ * @param[in] context       User defined context passed to the response handler
  *
  * @return  length of the packet
  * @return  0 if cannot send
  */
-size_t gcoap_req_send(const uint8_t *buf, size_t len, const ipv6_addr_t *addr,
-                      uint16_t port, gcoap_resp_handler_t resp_handler);
+size_t gcoap_req_send(const uint8_t *buf, size_t len,
+                      const ipv6_addr_t *addr, uint16_t port,
+                      gcoap_resp_handler_t resp_handler, void *context);
 
 /**
  * @brief   Initializes a CoAP response packet on a buffer

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -152,7 +152,7 @@ static int _update_remove(unsigned code, gcoap_resp_handler_t handle)
     ssize_t pkt_len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
 
     /* send request */
-    gcoap_req_send2(buf, pkt_len, &_rd_remote, handle);
+    gcoap_req_send2(buf, pkt_len, &_rd_remote, handle, NULL);
 
     /* synchronize response */
     return _sync();
@@ -224,7 +224,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
     gcoap_add_qstring(&pkt, "rt", "core.rd");
     size_t pkt_len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
-    res = gcoap_req_send2(buf, pkt_len, remote, _on_discover);
+    res = gcoap_req_send2(buf, pkt_len, remote, _on_discover, NULL);
     if (res < 0) {
         return CORD_EP_ERR;
     }
@@ -290,7 +290,7 @@ int cord_ep_register(const sock_udp_ep_t *remote, const char *regif)
     pkt_len = gcoap_finish(&pkt, res, COAP_FORMAT_LINK);
 
     /* send out the request */
-    res = gcoap_req_send2(buf, pkt_len, remote, _on_register);
+    res = gcoap_req_send2(buf, pkt_len, remote, _on_register, NULL);
     if (res < 0) {
         retval = CORD_EP_ERR;
         goto end;

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -60,7 +60,7 @@ int cord_epsim_register(void)
     }
     /* finish, we don't have any payload */
     ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
-    if (gcoap_req_send2(buf, len, &remote, NULL) == 0) {
+    if (gcoap_req_send2(buf, len, &remote, NULL, NULL) == 0) {
         return CORD_EPSIM_ERROR;
     }
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -233,7 +233,7 @@ static void _listen(sock_udp_t *sock)
                 xtimer_remove(&memo->response_timer);
                 memo->state = GCOAP_MEMO_RESP;
                 if (memo->resp_handler) {
-                    memo->resp_handler(memo->state, &pdu, &remote);
+                    memo->resp_handler(memo, &pdu, &remote);
                 }
 
                 if (memo->send_limit >= 0) {        /* if confirmable */
@@ -501,7 +501,7 @@ static void _expire_request(gcoap_request_memo_t *memo)
             else {
                 req.hdr = (coap_hdr_t *)memo->msg.data.pdu_buf;
             }
-            memo->resp_handler(memo->state, &req, NULL);
+            memo->resp_handler(memo, &req, NULL);
         }
         if (memo->send_limit != GCOAP_SEND_LIMIT_NON) {
             *memo->msg.data.pdu_buf = 0;    /* clear resend buffer */

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -775,8 +775,9 @@ ssize_t gcoap_finish(coap_pkt_t *pdu, size_t payload_len, unsigned format)
     return _finish_pdu(pdu, (uint8_t *)pdu->hdr, len);
 }
 
-size_t gcoap_req_send(const uint8_t *buf, size_t len, const ipv6_addr_t *addr,
-                      uint16_t port, gcoap_resp_handler_t resp_handler)
+size_t gcoap_req_send(const uint8_t *buf, size_t len,
+                      const ipv6_addr_t *addr, uint16_t port,
+                      gcoap_resp_handler_t resp_handler, void *context)
 {
     sock_udp_ep_t remote;
 
@@ -786,12 +787,12 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len, const ipv6_addr_t *addr,
 
     memcpy(&remote.addr.ipv6[0], &addr->u8[0], sizeof(addr->u8));
 
-    return gcoap_req_send2(buf, len, &remote, resp_handler);
+    return gcoap_req_send2(buf, len, &remote, resp_handler, context);
 }
 
 size_t gcoap_req_send2(const uint8_t *buf, size_t len,
                        const sock_udp_ep_t *remote,
-                       gcoap_resp_handler_t resp_handler)
+                       gcoap_resp_handler_t resp_handler, void *context)
 {
     gcoap_request_memo_t *memo = NULL;
     unsigned msg_type  = (*buf & 0x30) >> 4;
@@ -818,6 +819,7 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
         }
 
         memo->resp_handler = resp_handler;
+        memo->context = context;
         memcpy(&memo->remote_ep, remote, sizeof(sock_udp_ep_t));
 
         switch (msg_type) {


### PR DESCRIPTION
### Contribution description
This PR advances use of this branch for PR #9857 to upstream RIOT. It updates the cord_ep and cord_epsim example response handlers to the changes in this branch, particularly the addition of the request memo. It also adds the context parameter to the gcoap_req_init() calls in those examples.

This PR also adds documentation to gcoap_resp_handler_t callback function.